### PR TITLE
Enable complex types in outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,32 @@ mytype "test" {
 }
 ```
 
+#### element(list | map, int | string)
+Returns a value from a map or list by the given index. 
+
+```javascript
+variable "property" {
+  default = "name"
+}
+
+mytype "test1" {
+  // trimmed = "abc 123"
+  item {
+    name = "nic"
+  }
+  
+  item {
+    name = "eric"
+  }
+}
+
+mytype "test2" {
+  item {
+    name = element(resource.mytype.test1.0, variable property)
+  }
+}
+```
+
 ### Custom Functions
 
 In addition to the default functions it is possible to register custom functions.

--- a/README.md
+++ b/README.md
@@ -435,6 +435,40 @@ module "my_other_module" {
 }
 ```
 
+Outputs can also contain complex types like lists ...
+
+```javascript
+output "connection_string_list" {
+  value = [
+    resource.postgres.mydb1.connection_string,
+    resource.postgres.mydb2.connection_string
+  ]
+}
+```
+
+and maps ...
+
+```javascript
+output "connection_string_map" {
+  value = {
+    connection1 = resource.postgres.mydb1.connection_string
+    connection2 = resource.postgres.mydb2.connection_string
+  }
+}
+```
+
+It is possible to consume these values like so ...
+
+```javascript
+output "connection_string_list_1" {
+  value = output.connection_string_list.0
+}
+
+output "connection_string_map_1" {
+  value = output.connection_string_map.connection1
+}
+```
+
 ## Functions
 
 HCLConfig supports functions that can be used inside your configuration

--- a/config_test.go
+++ b/config_test.go
@@ -139,6 +139,14 @@ func TestFindResourceFindsModuleOutput(t *testing.T) {
 	require.Equal(t, r[7], out)
 }
 
+func TestFindResourceFindsModuleOutputWithIndex(t *testing.T) {
+	c, r := testSetupConfig(t)
+
+	out, err := c.FindResource("module.module1.module2.output.fqdn.0")
+	require.NoError(t, err)
+	require.Equal(t, r[7], out)
+}
+
 func TestFindResourceFindsClusterInModule(t *testing.T) {
 	c, r := testSetupConfig(t)
 

--- a/dag.go
+++ b/dag.go
@@ -345,7 +345,6 @@ func (c *Config) createCallback(wf ProcessCallback) func(v dag.Vertex) (diags tf
 			}
 
 			// we need to set src in the context
-			fmt.Printf("%s, %s\n", v, paramType)
 			var val cty.Value
 			switch paramType {
 			case "string":

--- a/dag.go
+++ b/dag.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform/tfdiags"
 	"github.com/jumppad-labs/hclconfig/lookup"
 	"github.com/jumppad-labs/hclconfig/types"
+	"github.com/kr/pretty"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -374,6 +375,8 @@ func (c *Config) createCallback(wf ProcessCallback) func(v dag.Vertex) (diags tf
 
 				val = cty.SetVal(vals)
 			case "cty.Value":
+				fmt.Println("p",path)
+				pretty.Println(src)
 				val = src.Interface().(cty.Value)
 
 			default:
@@ -386,6 +389,7 @@ func (c *Config) createCallback(wf ProcessCallback) func(v dag.Vertex) (diags tf
 				return diags.Append(pe)
 			}
 
+			fmt.Println(v)
 			err = setContextVariableFromPath(ctx, v, val)
 			if err != nil {
 				pe := ParserError{}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/hashicorp/go-getter v1.7.0
 	github.com/hashicorp/hcl2 v0.0.0-20191002203319-fb75b3253c80
 	github.com/hashicorp/terraform v0.12.29
+	github.com/kr/pretty v0.2.1
 	github.com/mailgun/raymond/v2 v2.0.48
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/stretchr/testify v1.8.1
@@ -39,7 +40,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.3.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/klauspost/compress v1.15.11 // indirect
-	github.com/kr/pretty v0.2.1 // indirect
+	github.com/kr/text v0.1.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/parse_test.go
+++ b/parse_test.go
@@ -263,7 +263,7 @@ func TestParseModuleCreatesResources(t *testing.T) {
 	c, err := p.ParseFile(absoluteFolderPath)
 	require.NoError(t, err)
 
-	require.Len(t, c.Resources, 33)
+	require.Len(t, c.Resources, 35)
 
 	// check resource has been created
 	cont, err := c.FindResource("module.consul_1.resource.container.consul")
@@ -536,7 +536,10 @@ func TestSetContextVariableFromPathWithEndingIndex(t *testing.T) {
 	ctx := &hcl.EvalContext{}
 	ctx.Variables = map[string]cty.Value{"resource": cty.ObjectVal(map[string]cty.Value{})}
 
-	err := setContextVariableFromPath(ctx, "resource.foo.bar[0]", cty.BoolVal(true))
+	err := setContextVariableFromPath(ctx, "resource.foo.bar", cty.ListVal([]cty.Value{cty.BoolVal(false), cty.BoolVal(false)}))
+	require.NoError(t, err)
+
+	err = setContextVariableFromPath(ctx, "resource.foo.bar[0]", cty.BoolVal(true))
 	require.NoError(t, err)
 
 	err = setContextVariableFromPath(ctx, "resource.foo.bar[1]", cty.BoolVal(false))

--- a/parse_test.go
+++ b/parse_test.go
@@ -164,6 +164,15 @@ func TestParseResolvesArrayReferences(t *testing.T) {
 
 	out = r.(*types.Output)
 	require.Equal(t, "10.7.0.201", out.Value)
+
+	r, err = c.FindResource("output.ip_addresses")
+	require.NoError(t, err)
+	require.NotNil(t, r)
+
+	out = r.(*types.Output)
+	require.Equal(t, "10.6.0.200", out.Value.([]interface{})[0].(string))
+	require.Equal(t, "10.7.0.201", out.Value.([]interface{})[1].(string))
+	require.Equal(t, float64(12), out.Value.([]interface{})[2].(float64))
 }
 
 func TestLoadsVariableFilesInOptionsOverridingVariableDefaults(t *testing.T) {
@@ -254,8 +263,7 @@ func TestParseModuleCreatesResources(t *testing.T) {
 	c, err := p.ParseFile(absoluteFolderPath)
 	require.NoError(t, err)
 
-	// count the resources, should create 4
-	require.Len(t, c.Resources, 23)
+	require.Len(t, c.Resources, 33)
 
 	// check resource has been created
 	cont, err := c.FindResource("module.consul_1.resource.container.consul")
@@ -277,24 +285,64 @@ func TestParseModuleCreatesResources(t *testing.T) {
 	// check interpolation value
 	require.Equal(t, "onprem", cont.(*structs.Container).Networks[0].Name)
 
-	// check outputs
-	cont, err = c.FindResource("output.module1_container_resources_cpu")
+}
+
+func TestParseModuleCreatesOutputs(t *testing.T) {
+	absoluteFolderPath, err := filepath.Abs("./test_fixtures/modules/modules.hcl")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := setupParser(t)
+
+	c, err := p.ParseFile(absoluteFolderPath)
 	require.NoError(t, err)
 
-	// check interpolation value is overriden in the module stanza
-	require.Equal(t, "4096", cont.(*types.Output).Value)
+	require.Len(t, c.Resources, 35)
+
+	cont, err := c.FindResource("output.module1_container_resources_cpu")
+	require.NoError(t, err)
+
+	// check output value from module is equal to the module variable
+	// which is set as an interpolated value of the container base
+	require.Equal(t, float64(4096), cont.(*types.Output).Value)
 
 	cont, err = c.FindResource("output.module2_container_resources_cpu")
 	require.NoError(t, err)
 
-	// check interpolation value
-	require.Equal(t, "512", cont.(*types.Output).Value)
+	// check output value from module is equal to the module variable
+	// which is set as the variable for the config
+	require.Equal(t, float64(512), cont.(*types.Output).Value)
 
 	cont, err = c.FindResource("output.module3_container_resources_cpu")
 	require.NoError(t, err)
 
-	// check interpolation value
-	require.Equal(t, "2048", cont.(*types.Output).Value)
+	// check the output variable is set to the default value for the module
+	require.Equal(t, float64(2048), cont.(*types.Output).Value)
+
+	cont, err = c.FindResource("output.module1_from_list_1")
+	require.NoError(t, err)
+
+	cont2, err := c.FindResource("output.module1_from_list_2")
+	require.NoError(t, err)
+
+	// check an element can be obtained from a list of values
+	// returned from a output
+	require.Equal(t, float64(0), cont.(*types.Output).Value)
+	require.Equal(t, float64(4096), cont2.(*types.Output).Value)
+
+	// check an element can be obtained from a map of values
+	// returned from a output
+	cont, err = c.FindResource("output.module1_from_map_1")
+	require.NoError(t, err)
+
+	cont2, err = c.FindResource("output.module1_from_map_2")
+	require.NoError(t, err)
+
+	// check element can be obtained from a map of values
+	// returned in the output
+	require.Equal(t, "consul", cont.(*types.Output).Value)
+	require.Equal(t, float64(4096), cont2.(*types.Output).Value)
 }
 
 func TestDoesNotLoadsVariablesFilesFromInsideModules(t *testing.T) {
@@ -420,17 +468,99 @@ func TestParseDoesNotProcessDisabledResourcesWhenModuleDisabled(t *testing.T) {
 	require.Len(t, calls, 0)
 }
 
+func TestGetNameAndIndexReturnsCorrectDetails(t *testing.T) {
+	path := []string{"resource", "foo", "bar"}
+	n, i, rp, err := getNameAndIndex(path)
+	require.NoError(t, err)
+	require.Equal(t, "resource", n)
+	require.Equal(t, -1, i)
+	require.Equal(t, []string{"foo", "bar"}, rp)
+
+	path = []string{"resource", "foo[0]", "bar"}
+	n, i, rp, err = getNameAndIndex(path)
+	require.NoError(t, err)
+	require.Equal(t, "resource", n)
+	require.Equal(t, -1, i)
+	require.Equal(t, []string{"foo[0]", "bar"}, rp)
+
+	path = []string{"foo[0]", "bar"}
+	n, i, rp, err = getNameAndIndex(path)
+	require.NoError(t, err)
+	require.Equal(t, "foo", n)
+	require.Equal(t, 0, i)
+	require.Equal(t, []string{"bar"}, rp)
+
+	path = []string{"foo[nic]", "bar"}
+	_, _, _, err = getNameAndIndex(path)
+	require.Error(t, err)
+
+	path = []string{"foo", "0", "bar"}
+	n, i, rp, err = getNameAndIndex(path)
+	require.NoError(t, err)
+	require.Equal(t, "foo", n)
+	require.Equal(t, 0, i)
+	require.Equal(t, []string{"bar"}, rp)
+
+	path = []string{"bar[0]"}
+	n, i, rp, err = getNameAndIndex(path)
+	require.NoError(t, err)
+	require.Equal(t, "bar", n)
+	require.Equal(t, 0, i)
+	require.Equal(t, []string{}, rp)
+}
+
 func TestSetContextVariableFromPath(t *testing.T) {
 	ctx := &hcl.EvalContext{}
 	ctx.Variables = map[string]cty.Value{"resource": cty.ObjectVal(map[string]cty.Value{})}
 
-	setContextVariableFromPath(ctx, "resource.foo.bar", cty.BoolVal(true))
-	setContextVariableFromPath(ctx, "resource.foo.bear", cty.StringVal("Hello World"))
-	setContextVariableFromPath(ctx, "resource.poo", cty.StringVal("Meh"))
+	err := setContextVariableFromPath(ctx, "resource.foo.bar", cty.BoolVal(true))
+	require.NoError(t, err)
+
+	err = setContextVariableFromPath(ctx, "resource.foo.biz", cty.StringVal("Hello World"))
+	require.NoError(t, err)
+
+	err = setContextVariableFromPath(ctx, "resource.foo.bear.grr", cty.StringVal("Grrrr"))
+
+	require.NoError(t, err)
+
+	err = setContextVariableFromPath(ctx, "resource.poo", cty.StringVal("Meh"))
+	require.NoError(t, err)
 
 	require.True(t, ctx.Variables["resource"].AsValueMap()["foo"].AsValueMap()["bar"].True())
-	require.Equal(t, "Hello World", ctx.Variables["resource"].AsValueMap()["foo"].AsValueMap()["bear"].AsString())
+	require.Equal(t, "Hello World", ctx.Variables["resource"].AsValueMap()["foo"].AsValueMap()["biz"].AsString())
+	require.Equal(t, "Grrrr", ctx.Variables["resource"].AsValueMap()["foo"].AsValueMap()["bear"].AsValueMap()["grr"].AsString())
 	require.Equal(t, "Meh", ctx.Variables["resource"].AsValueMap()["poo"].AsString())
+}
+
+func TestSetContextVariableFromPathWithEndingIndex(t *testing.T) {
+	ctx := &hcl.EvalContext{}
+	ctx.Variables = map[string]cty.Value{"resource": cty.ObjectVal(map[string]cty.Value{})}
+
+	err := setContextVariableFromPath(ctx, "resource.foo.bar[0]", cty.BoolVal(true))
+	require.NoError(t, err)
+
+	err = setContextVariableFromPath(ctx, "resource.foo.bar[1]", cty.BoolVal(false))
+
+	require.NoError(t, err)
+
+	require.True(t, ctx.Variables["resource"].AsValueMap()["foo"].AsValueMap()["bar"].AsValueSlice()[0].True())
+	require.False(t, ctx.Variables["resource"].AsValueMap()["foo"].AsValueMap()["bar"].AsValueSlice()[1].True())
+}
+
+func TestSetContextVariableFromPathWithIndex(t *testing.T) {
+	ctx := &hcl.EvalContext{}
+	ctx.Variables = map[string]cty.Value{"resource": cty.ObjectVal(map[string]cty.Value{})}
+
+	err := setContextVariableFromPath(ctx, "resource.foo[0].bar", cty.BoolVal(true))
+	require.NoError(t, err)
+
+	err = setContextVariableFromPath(ctx, "resource.foo.1.biz", cty.StringVal("Hello World"))
+
+	require.NoError(t, err)
+
+	fmt.Println(ctx.Variables["resource"].AsValueMap()["foo"].Type().FriendlyName())
+	require.True(t, ctx.Variables["resource"].AsValueMap()["foo"].AsValueSlice()[0].AsValueMap()["bar"].True())
+	require.Equal(t, "Hello World", ctx.Variables["resource"].AsValueMap()["foo"].AsValueSlice()[1].AsValueMap()["biz"].AsString())
 }
 
 func TestParserProcessesResourcesInCorrectOrder(t *testing.T) {
@@ -540,7 +670,7 @@ func TestParserStopsParseOnCallbackError(t *testing.T) {
 	require.Error(t, err)
 
 	// only 7 of the resources should be created, none of the descendants of base
-	require.Len(t, calls, 6)
+	require.Len(t, calls, 8)
 	require.NotContains(t, "resource.module.consul_1", calls)
 }
 

--- a/test_fixtures/modules/modules.hcl
+++ b/test_fixtures/modules/modules.hcl
@@ -40,14 +40,51 @@ module "consul_3" {
   source     = "../single"
 }
 
+// returns a simple type from the ouput of the module
 output "module1_container_resources_cpu" {
   value = module.consul_1.output.container_resources_cpu
 }
 
+// returns a simple type from the ouput of the module
 output "module2_container_resources_cpu" {
   value = module.consul_2.output.container_resources_cpu
 }
 
+// returns a simple type from the ouput of the module
 output "module3_container_resources_cpu" {
   value = module.consul_3.output.container_resources_cpu
+}
+
+// returns an element using a numeric index from a list 
+// returned from the output
+output "module1_from_list_1" {
+  value = element(module.consul_1.output.combined_list, 0)
+}
+
+//// returns an element using a numeric index from a list 
+//// returned from the output
+output "module1_from_list_2" {
+  value = element(module.consul_1.output.combined_list, 1)
+}
+
+// returns an element using a numeric index from a list 
+// returned from the output
+output "module1_from_list_3" {
+  value = module.consul_1.output.combined_list.0
+}
+
+// returns an element using a string index from a map
+// returned from the output
+output "module1_from_map_1" {
+  value = element(module.consul_1.output.combined_map, "name")
+}
+
+// returns an element using a string index from a map
+// returned from the output
+output "module1_from_map_2" {
+  value = element(module.consul_1.output.combined_map, "cpu")
+}
+
+output "module1_from_map_3" {
+  value = module.consul_1.output.combined_map.name
 }

--- a/test_fixtures/simple/container.hcl
+++ b/test_fixtures/simple/container.hcl
@@ -132,3 +132,11 @@ output "ip_address_1" {
 output "ip_address_2" {
   value = resource.container.consul.network.1.ip_address
 }
+
+output "ip_addresses" {
+  value = [
+    resource.container.consul.network.0.ip_address,
+    resource.container.consul.network.1.ip_address,
+    12
+  ]
+}

--- a/test_fixtures/single/container.hcl
+++ b/test_fixtures/single/container.hcl
@@ -35,3 +35,17 @@ output "container_name" {
 output "container_resources_cpu" {
   value = resource.container.consul.resources.cpu
 }
+
+output "combined_list" {
+  value = [
+    resource.container.consul.resources.memory,
+    resource.container.consul.resources.cpu
+  ]
+}
+
+output "combined_map" {
+  value = {
+    name = resource.container.consul.name
+    cpu  = resource.container.consul.resources.cpu
+  }
+}

--- a/types/fqdn_test.go
+++ b/types/fqdn_test.go
@@ -153,6 +153,71 @@ func TestParseFQRNReturnsOutput(t *testing.T) {
 	require.Equal(t, "output.mine", sfrqn)
 }
 
+func TestParseResourceFQRNWithIndexReturnsCorrectData(t *testing.T) {
+	fqrn, err := ParseFQRN("resource.container.mine.property.0")
+	require.NoError(t, err)
+
+	require.Equal(t, "", fqrn.Module)
+	require.Equal(t, typeTestContainer, fqrn.Type)
+	require.Equal(t, "mine", fqrn.Resource)
+	require.Equal(t, "property.0", fqrn.Attribute)
+
+	sfrqn := fqrn.String()
+	require.Equal(t, "resource.container.mine.property.0", sfrqn)
+}
+
+func TestParseFQRNWithIndexReturnsCorrectData(t *testing.T) {
+	fqrn, err := ParseFQRN("output.mine.0")
+	require.NoError(t, err)
+
+	require.Equal(t, "", fqrn.Module)
+	require.Equal(t, TypeOutput, fqrn.Type)
+	require.Equal(t, "mine", fqrn.Resource)
+	require.Equal(t, "0", fqrn.Attribute)
+
+	sfrqn := fqrn.String()
+	require.Equal(t, "output.mine.0", sfrqn)
+}
+
+func TestParseFQRNWithParenthesesIndexReturnsCorrectData(t *testing.T) {
+	fqrn, err := ParseFQRN("output.mine[0]")
+	require.NoError(t, err)
+
+	require.Equal(t, "", fqrn.Module)
+	require.Equal(t, TypeOutput, fqrn.Type)
+	require.Equal(t, "mine", fqrn.Resource)
+	require.Equal(t, "0", fqrn.Attribute)
+
+	sfrqn := fqrn.String()
+	require.Equal(t, "output.mine.0", sfrqn)
+}
+
+func TestParseFQRNWithParenthesesIndexAndAttributeReturnsCorrectData(t *testing.T) {
+	fqrn, err := ParseFQRN("output.mine[0].nic")
+	require.NoError(t, err)
+
+	require.Equal(t, "", fqrn.Module)
+	require.Equal(t, TypeOutput, fqrn.Type)
+	require.Equal(t, "mine", fqrn.Resource)
+	require.Equal(t, "0.nic", fqrn.Attribute)
+
+	sfrqn := fqrn.String()
+	require.Equal(t, "output.mine.0.nic", sfrqn)
+}
+
+func TestParseFQRNWithIndexAndModuleReturnsCorrectData(t *testing.T) {
+	fqrn, err := ParseFQRN("module.mine.output.mine.name")
+	require.NoError(t, err)
+
+	require.Equal(t, "mine", fqrn.Module)
+	require.Equal(t, TypeOutput, fqrn.Type)
+	require.Equal(t, "mine", fqrn.Resource)
+	require.Equal(t, "name", fqrn.Attribute)
+
+	sfrqn := fqrn.String()
+	require.Equal(t, "module.mine.output.mine.name", sfrqn)
+}
+
 func TestFQRNFromResourceReturnsCorrectData(t *testing.T) {
 	dt := DefaultTypes()
 	dt[typeTestContainer] = &testContainer{}

--- a/types/output.go
+++ b/types/output.go
@@ -9,6 +9,6 @@ type Output struct {
 	ResourceMetadata `hcl:",remain"`
 
 	CtyValue    cty.Value   `hcl:"value,optional"` // value of the output
-	Value       interface{} `json"value"`
+	Value       interface{} `json:"value"`
 	Description string      `hcl:"description,optional" json:"description,omitempty"` // description for the output
 }

--- a/types/output.go
+++ b/types/output.go
@@ -1,11 +1,14 @@
 package types
 
+import "github.com/zclconf/go-cty/cty"
+
 const TypeOutput = "output"
 
 // Output defines an output variable which can be set by a module
 type Output struct {
 	ResourceMetadata `hcl:",remain"`
 
-	Value       string `hcl:"value,optional" json:"value,omitempty"`             // value of the output
-	Description string `hcl:"description,optional" json:"description,omitempty"` // description for the output
+	CtyValue    cty.Value   `hcl:"value,optional"` // value of the output
+	Value       interface{} `json"value"`
+	Description string      `hcl:"description,optional" json:"description,omitempty"` // description for the output
 }

--- a/utils.go
+++ b/utils.go
@@ -1,7 +1,11 @@
 package hclconfig
 
 import (
+	"fmt"
+
+	"github.com/kr/pretty"
 	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
 )
 
 // ParseVars converts a map[string]cty.Value into map[string]interface
@@ -44,6 +48,13 @@ func castVar(v cty.Value) interface{} {
 		}
 
 		return vars
+	} else if v.Type() == cty.DynamicPseudoType {
+		v, err := convert.Convert(v, cty.String)
+		if err == nil {
+			pretty.Println(v)
+			fmt.Printf("dynamic %v %s\n", v.AsString(), err)
+			return v
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Outputs can now contain complex types like lists ...

```javascript
output "connection_string_list" {
  value = [
    resource.postgres.mydb1.connection_string,
    resource.postgres.mydb2.connection_string
  ]
}
```

and maps ...

```javascript
output "connection_string_map" {
  value = {
    connection1 = resource.postgres.mydb1.connection_string
    connection2 = resource.postgres.mydb2.connection_string
  }
}
```