### PR TITLE
Rename fields in resource to avoid conflicts with user defined fields

### DIFF
--- a/config.go
+++ b/config.go
@@ -86,9 +86,9 @@ func (c *Config) FindResource(path string) (types.Resource, error) {
 	}
 
 	for _, r := range c.Resources {
-		if r.Metadata().Module == fqdn.Module &&
-			r.Metadata().Type == fqdn.Type &&
-			r.Metadata().Name == fqdn.Resource {
+		if r.Metadata().ResourceModule == fqdn.Module &&
+			r.Metadata().ResourceType == fqdn.Type &&
+			r.Metadata().ResourceName == fqdn.Resource {
 			return r, nil
 		}
 	}
@@ -123,7 +123,7 @@ func (c *Config) FindResourcesByType(t string) ([]types.Resource, error) {
 	res := []types.Resource{}
 
 	for _, r := range c.Resources {
-		if r.Metadata().Type == t {
+		if r.Metadata().ResourceType == t {
 			res = append(res, r)
 		}
 	}
@@ -156,11 +156,11 @@ func (c *Config) FindModuleResources(module string, includeSubModules bool) ([]t
 
 	for _, r := range c.Resources {
 		match := false
-		if includeSubModules && strings.HasPrefix(r.Metadata().Module, moduleString) {
+		if includeSubModules && strings.HasPrefix(r.Metadata().ResourceModule, moduleString) {
 			match = true
 		}
 
-		if !includeSubModules && r.Metadata().Module == moduleString {
+		if !includeSubModules && r.Metadata().ResourceModule == moduleString {
 			match = true
 		}
 
@@ -260,7 +260,7 @@ func (c *Config) Diff(o *Config) (*ResourceDiff, error) {
 
 	for _, r := range o.Resources {
 		// does the resource exist
-		cr, err := c.FindResource(r.Metadata().ID)
+		cr, err := c.FindResource(r.Metadata().ResourceID)
 
 		// check if the resource has been found
 		if err != nil {
@@ -270,13 +270,13 @@ func (c *Config) Diff(o *Config) (*ResourceDiff, error) {
 		}
 
 		// check if the resource has changed
-		if cr.Metadata().SourceChecksum.Parsed != r.Metadata().SourceChecksum.Parsed {
+		if cr.Metadata().ResourceChecksum.Parsed != r.Metadata().ResourceChecksum.Parsed {
 			// resource has changes rebuild
 			parseChanged = append(parseChanged, r)
 			continue
 		}
 
-		if cr.Metadata().SourceChecksum.Processed != r.Metadata().SourceChecksum.Processed {
+		if cr.Metadata().ResourceChecksum.Processed != r.Metadata().ResourceChecksum.Processed {
 			// resource has changes rebuild
 			processChanged = append(processChanged, r)
 			continue
@@ -288,7 +288,7 @@ func (c *Config) Diff(o *Config) (*ResourceDiff, error) {
 	for _, r := range c.Resources {
 		found := false
 		for _, r2 := range o.Resources {
-			if r.Metadata().ID == r2.Metadata().ID {
+			if r.Metadata().ResourceID == r2.Metadata().ResourceID {
 				found = true
 				break
 			}
@@ -303,28 +303,28 @@ func (c *Config) Diff(o *Config) (*ResourceDiff, error) {
 	for _, r := range c.Resources {
 		found := false
 		for _, r2 := range new {
-			if r.Metadata().ID == r2.Metadata().ID {
+			if r.Metadata().ResourceID == r2.Metadata().ResourceID {
 				found = true
 				break
 			}
 		}
 
 		for _, r2 := range parseChanged {
-			if r.Metadata().ID == r2.Metadata().ID {
+			if r.Metadata().ResourceID == r2.Metadata().ResourceID {
 				found = true
 				break
 			}
 		}
 
 		for _, r2 := range processChanged {
-			if r.Metadata().ID == r2.Metadata().ID {
+			if r.Metadata().ResourceID == r2.Metadata().ResourceID {
 				found = true
 				break
 			}
 		}
 
 		for _, r2 := range removed {
-			if r.Metadata().ID == r2.Metadata().ID {
+			if r.Metadata().ResourceID == r2.Metadata().ResourceID {
 				found = true
 				break
 			}
@@ -351,9 +351,9 @@ func (c *Config) RemoveResource(rf types.Resource) error {
 
 	pos := -1
 	for i, r := range c.Resources {
-		if rf.Metadata().Name == r.Metadata().Name &&
-			rf.Metadata().Type == r.Metadata().Type &&
-			rf.Metadata().Module == r.Metadata().Module {
+		if rf.Metadata().ResourceName == r.Metadata().ResourceName &&
+			rf.Metadata().ResourceType == r.Metadata().ResourceType &&
+			rf.Metadata().ResourceModule == r.Metadata().ResourceModule {
 			pos = i
 			break
 		}
@@ -403,7 +403,7 @@ func (c *Config) Walk(wf WalkCallback, reverse bool) error {
 			}
 
 			// if this is the root module or is disabled skip
-			if (r.Metadata().Type == types.TypeRoot || r.Metadata().Type == types.TypeModule) || r.Metadata().Disabled {
+			if (r.Metadata().ResourceType == types.TypeRoot || r.Metadata().ResourceType == types.TypeModule) || r.Metadata().Disabled {
 				return nil
 			}
 
@@ -479,11 +479,11 @@ func (c *Config) addResource(r types.Resource, ctx *hcl.EvalContext, b *hclsynta
 	fqdn := types.FQDNFromResource(r)
 
 	// set the ID
-	r.Metadata().ID = fqdn.String()
+	r.Metadata().ResourceID = fqdn.String()
 
 	rf, err := c.FindResource(fqdn.String())
 	if err == nil && rf != nil {
-		return ResourceExistsError{r.Metadata().Name}
+		return ResourceExistsError{r.Metadata().ResourceName}
 	}
 
 	c.Resources = append(c.Resources, r)

--- a/dag.go
+++ b/dag.go
@@ -27,7 +27,7 @@ func doYaLikeDAGs(c *Config) (*dag.AcyclicGraph, error) {
 	// Loop over all resources and add to graph
 	for _, resource := range c.Resources {
 		// ignore variables
-		if resource.Metadata().Type != types.TypeVariable {
+		if resource.Metadata().ResourceType != types.TypeVariable {
 			graph.Add(resource)
 		}
 	}
@@ -37,7 +37,7 @@ func doYaLikeDAGs(c *Config) (*dag.AcyclicGraph, error) {
 		hasDeps := false
 
 		// do nothing with variables
-		if resource.Metadata().Type == types.TypeVariable {
+		if resource.Metadata().ResourceType == types.TypeVariable {
 			continue
 		}
 
@@ -65,9 +65,9 @@ func doYaLikeDAGs(c *Config) (*dag.AcyclicGraph, error) {
 			fqdn, err := types.ParseFQRN(d)
 			if err != nil {
 				pe := errors.ParserError{}
-				pe.Line = resource.Metadata().SourceLine
-				pe.Column = resource.Metadata().SourceColumn
-				pe.Filename = resource.Metadata().SourceFile
+				pe.Line = resource.Metadata().ResourceLine
+				pe.Column = resource.Metadata().ResourceColumn
+				pe.Filename = resource.Metadata().ResourceFile
 				pe.Message = fmt.Sprintf("invalid dependency: %s, error: %s", d, err)
 				pe.Level = errors.ParserErrorLevelError
 
@@ -81,13 +81,13 @@ func doYaLikeDAGs(c *Config) (*dag.AcyclicGraph, error) {
 				// "module1" and the reference is "module.module2.resource.container.mine.id"
 				// then the reference should be modified to include the parent reference
 				// "module.module1.module2.resource.container.mine.id"
-				relFQDN := fqdn.AppendParentModule(resource.Metadata().Module)
+				relFQDN := fqdn.AppendParentModule(resource.Metadata().ResourceModule)
 				deps, err := c.FindModuleResources(relFQDN.String(), true)
 				if err != nil {
 					pe := errors.ParserError{}
-					pe.Line = resource.Metadata().SourceLine
-					pe.Column = resource.Metadata().SourceColumn
-					pe.Filename = resource.Metadata().SourceFile
+					pe.Line = resource.Metadata().ResourceLine
+					pe.Column = resource.Metadata().ResourceColumn
+					pe.Filename = resource.Metadata().ResourceFile
 					pe.Message = fmt.Sprintf("unable to find resources for module: %s, error: %s", fqdn.Module, err)
 					pe.Level = errors.ParserErrorLevelError
 
@@ -106,14 +106,14 @@ func doYaLikeDAGs(c *Config) (*dag.AcyclicGraph, error) {
 				// "module1" and the reference is "module.module2.resource.container.mine.id"
 				// then the reference should be modified to include the parent reference
 				// "module.module1.module2.resource.container.mine.id"
-				relFQDN := fqdn.AppendParentModule(resource.Metadata().Module)
+				relFQDN := fqdn.AppendParentModule(resource.Metadata().ResourceModule)
 				dep, err := c.FindResource(relFQDN.String())
 				if err != nil {
 					pe := errors.ParserError{}
-					pe.Line = resource.Metadata().SourceLine
-					pe.Column = resource.Metadata().SourceColumn
-					pe.Filename = resource.Metadata().SourceFile
-					pe.Message = fmt.Sprintf("unable to find dependent resource in module: '%s', error: '%s'", resource.Metadata().Module, err)
+					pe.Line = resource.Metadata().ResourceLine
+					pe.Column = resource.Metadata().ResourceColumn
+					pe.Filename = resource.Metadata().ResourceFile
+					pe.Message = fmt.Sprintf("unable to find dependent resource in module: '%s', error: '%s'", resource.Metadata().ResourceModule, err)
 					pe.Level = errors.ParserErrorLevelError
 
 					return nil, pe
@@ -124,15 +124,15 @@ func doYaLikeDAGs(c *Config) (*dag.AcyclicGraph, error) {
 		}
 
 		// if this resource is part of a module make it depend on that module
-		if resource.Metadata().Module != "" {
-			fqdnString := fmt.Sprintf("module.%s", resource.Metadata().Module)
+		if resource.Metadata().ResourceModule != "" {
+			fqdnString := fmt.Sprintf("module.%s", resource.Metadata().ResourceModule)
 
 			d, err := c.FindResource(fqdnString)
 			if err != nil {
 				pe := errors.ParserError{}
-				pe.Line = resource.Metadata().SourceLine
-				pe.Column = resource.Metadata().SourceColumn
-				pe.Filename = resource.Metadata().SourceFile
+				pe.Line = resource.Metadata().ResourceLine
+				pe.Column = resource.Metadata().ResourceColumn
+				pe.Filename = resource.Metadata().ResourceFile
 				pe.Message = fmt.Sprintf("unable to find resources parent module: '%s, error: %s", fqdnString, err)
 				pe.Level = errors.ParserErrorLevelError
 
@@ -173,13 +173,13 @@ func createCallback(c *Config, wf WalkCallback) func(v dag.Vertex) (diags dag.Di
 		}
 
 		// if this is the root module or is disabled skip or is a variable
-		if (r.Metadata().Type == types.TypeRoot) || r.Metadata().Disabled || r.Metadata().Type == types.TypeVariable {
+		if (r.Metadata().ResourceType == types.TypeRoot) || r.Metadata().Disabled || r.Metadata().ResourceType == types.TypeVariable {
 			return nil
 		}
 
 		bdy, err := c.getBody(r)
 		if err != nil {
-			panic(fmt.Sprintf(`no body found for resource "%s"`, r.Metadata().ID))
+			panic(fmt.Sprintf(`no body found for resource "%s"`, r.Metadata().ResourceID))
 		}
 
 		ctx, err := c.getContext(r)
@@ -194,9 +194,9 @@ func createCallback(c *Config, wf WalkCallback) func(v dag.Vertex) (diags dag.Di
 			fqdn, err := types.ParseFQRN(v)
 			if err != nil {
 				pe := errors.ParserError{}
-				pe.Filename = r.Metadata().SourceFile
-				pe.Line = r.Metadata().SourceLine
-				pe.Column = r.Metadata().SourceColumn
+				pe.Filename = r.Metadata().ResourceFile
+				pe.Line = r.Metadata().ResourceLine
+				pe.Column = r.Metadata().ResourceColumn
 				pe.Message = fmt.Sprintf("error parsing resource link %s", err)
 				pe.Level = errors.ParserErrorLevelError
 
@@ -204,12 +204,12 @@ func createCallback(c *Config, wf WalkCallback) func(v dag.Vertex) (diags dag.Di
 			}
 
 			// get the value from the linked resource
-			l, err := c.FindRelativeResource(v, r.Metadata().Module)
+			l, err := c.FindRelativeResource(v, r.Metadata().ResourceModule)
 			if err != nil {
 				pe := errors.ParserError{}
-				pe.Filename = r.Metadata().SourceFile
-				pe.Line = r.Metadata().SourceLine
-				pe.Column = r.Metadata().SourceColumn
+				pe.Filename = r.Metadata().ResourceFile
+				pe.Line = r.Metadata().ResourceLine
+				pe.Column = r.Metadata().ResourceColumn
 				pe.Message = fmt.Sprintf(`unable to find dependent resource "%s" %s`, v, err)
 				pe.Level = errors.ParserErrorLevelError
 
@@ -220,7 +220,7 @@ func createCallback(c *Config, wf WalkCallback) func(v dag.Vertex) (diags dag.Di
 
 			// once we have found a resource convert it to a cty type and then
 			// set it on the context
-			switch l.Metadata().Type {
+			switch l.Metadata().ResourceType {
 			case types.TypeLocal:
 				loc := l.(*types.Local)
 				ctyRes = loc.CtyValue
@@ -233,9 +233,9 @@ func createCallback(c *Config, wf WalkCallback) func(v dag.Vertex) (diags dag.Di
 
 			if err != nil {
 				pe := errors.ParserError{}
-				pe.Filename = r.Metadata().SourceFile
-				pe.Line = r.Metadata().SourceLine
-				pe.Column = r.Metadata().SourceColumn
+				pe.Filename = r.Metadata().ResourceFile
+				pe.Line = r.Metadata().ResourceLine
+				pe.Column = r.Metadata().ResourceColumn
 				pe.Message = fmt.Sprintf(`unable to convert reference %s to context variable: %s`, v, err)
 				pe.Level = errors.ParserErrorLevelError
 
@@ -248,9 +248,9 @@ func createCallback(c *Config, wf WalkCallback) func(v dag.Vertex) (diags dag.Di
 			err = setContextVariableFromPath(ctx, fqdn.String(), ctyRes)
 			if err != nil {
 				pe := errors.ParserError{}
-				pe.Filename = r.Metadata().SourceFile
-				pe.Line = r.Metadata().SourceLine
-				pe.Column = r.Metadata().SourceColumn
+				pe.Filename = r.Metadata().ResourceFile
+				pe.Line = r.Metadata().ResourceLine
+				pe.Column = r.Metadata().ResourceColumn
 				pe.Message = fmt.Sprintf(`unable to set context variable: %s`, err)
 				pe.Level = errors.ParserErrorLevelError
 
@@ -266,9 +266,9 @@ func createCallback(c *Config, wf WalkCallback) func(v dag.Vertex) (diags dag.Di
 		diag := gohcl.DecodeBody(bdy, ctx, r)
 		if diag.HasErrors() {
 			pe := errors.ParserError{}
-			pe.Filename = r.Metadata().SourceFile
-			pe.Line = r.Metadata().SourceLine
-			pe.Column = r.Metadata().SourceColumn
+			pe.Filename = r.Metadata().ResourceFile
+			pe.Line = r.Metadata().ResourceLine
+			pe.Column = r.Metadata().ResourceColumn
 			pe.Message = fmt.Sprintf(`unable to decode body: %s`, diag.Error())
 			pe.Level = errors.ParserErrorLevelWarning
 
@@ -278,16 +278,16 @@ func createCallback(c *Config, wf WalkCallback) func(v dag.Vertex) (diags dag.Di
 		// if the type is a module the potentially we only just found out that we should be
 		// disabled
 		// as an additional check, set all module resources to disabled if the module is disabled
-		if r.Metadata().Disabled && r.Metadata().Type == types.TypeModule {
+		if r.Metadata().Disabled && r.Metadata().ResourceType == types.TypeModule {
 			// find all dependent resources
-			dr, err := c.FindModuleResources(r.Metadata().ID, true)
+			dr, err := c.FindModuleResources(r.Metadata().ResourceID, true)
 			if err != nil {
 				// should not be here unless an internal error
 				pe := errors.ParserError{}
-				pe.Filename = r.Metadata().SourceFile
-				pe.Line = r.Metadata().SourceLine
-				pe.Column = r.Metadata().SourceColumn
-				pe.Message = fmt.Sprintf(`unable to find disabled module resources "%s", %s"`, r.Metadata().ID, err)
+				pe.Filename = r.Metadata().ResourceFile
+				pe.Line = r.Metadata().ResourceLine
+				pe.Column = r.Metadata().ResourceColumn
+				pe.Message = fmt.Sprintf(`unable to find disabled module resources "%s", %s"`, r.Metadata().ResourceID, err)
 				pe.Level = errors.ParserErrorLevelError
 
 				return diags.Append(pe)
@@ -304,17 +304,17 @@ func createCallback(c *Config, wf WalkCallback) func(v dag.Vertex) (diags dag.Di
 		//
 		// if disabled was set through interpolation, the value has only been set here
 		// we need to handle an additional check
-		if !r.Metadata().Disabled && r.Metadata().Type != types.TypeModule {
+		if !r.Metadata().Disabled && r.Metadata().ResourceType != types.TypeModule {
 
 			// call the callbacks
 			if wf != nil {
 				err := wf(r)
 				if err != nil {
 					pe := errors.ParserError{}
-					pe.Filename = r.Metadata().SourceFile
-					pe.Line = r.Metadata().SourceLine
-					pe.Column = r.Metadata().SourceColumn
-					pe.Message = fmt.Sprintf(`error calling callback for resource "%s" %s`, r.Metadata().ID, err)
+					pe.Filename = r.Metadata().ResourceFile
+					pe.Line = r.Metadata().ResourceLine
+					pe.Column = r.Metadata().ResourceColumn
+					pe.Message = fmt.Sprintf(`error calling callback for resource "%s" %s`, r.Metadata().ResourceID, err)
 					pe.Level = errors.ParserErrorLevelError
 
 					return diags.Append(pe)
@@ -324,7 +324,7 @@ func createCallback(c *Config, wf WalkCallback) func(v dag.Vertex) (diags dag.Di
 
 		// if the type is a module we need to add the variables to the
 		// context
-		if r.Metadata().Type == types.TypeModule {
+		if r.Metadata().ResourceType == types.TypeModule {
 			mod := r.(*types.Module)
 
 			var mapVars map[string]cty.Value
@@ -340,7 +340,7 @@ func createCallback(c *Config, wf WalkCallback) func(v dag.Vertex) (diags dag.Di
 
 		// if this is an output or local we need to convert the value into
 		// a go type
-		if r.Metadata().Type == types.TypeOutput {
+		if r.Metadata().ResourceType == types.TypeOutput {
 			o := r.(*types.Output)
 
 			if !o.CtyValue.IsNull() {
@@ -348,7 +348,7 @@ func createCallback(c *Config, wf WalkCallback) func(v dag.Vertex) (diags dag.Di
 			}
 		}
 
-		if r.Metadata().Type == types.TypeLocal {
+		if r.Metadata().ResourceType == types.TypeLocal {
 			o := r.(*types.Local)
 
 			if !o.CtyValue.IsNull() {

--- a/example/main.go
+++ b/example/main.go
@@ -18,7 +18,7 @@ func main() {
 	// this function can be used to execute any external work required for the
 	// resource.
 	o.Callback = func(r types.Resource) error {
-		fmt.Printf("  resource '%s' named '%s' has been parsed from the file: %s\n", r.Metadata().Type, r.Metadata().Name, r.Metadata().SourceFile)
+		fmt.Printf("  resource '%s' named '%s' has been parsed from the file: %s\n", r.Metadata().ResourceType, r.Metadata().ResourceName, r.Metadata().ResourceFile)
 		return nil
 	}
 
@@ -61,7 +61,7 @@ func main() {
 
 	fmt.Println("## Process config")
 	nc.Walk(func(r types.Resource) error {
-		fmt.Println("  ", r.Metadata().ID)
+		fmt.Println("  ", r.Metadata().ResourceID)
 		return nil
 	}, false)
 
@@ -69,7 +69,7 @@ func main() {
 	fmt.Println("## Process config reverse")
 
 	nc.Walk(func(r types.Resource) error {
-		fmt.Println("  ", r.Metadata().ID)
+		fmt.Println("  ", r.Metadata().ResourceID)
 		return nil
 	}, true)
 
@@ -79,7 +79,7 @@ func printConfig(c *hclconfig.Config) {
 	fmt.Println("## Dump config")
 
 	for _, r := range c.Resources {
-		switch r.Metadata().Type {
+		switch r.Metadata().ResourceType {
 		case "config":
 			t := r.(*Config)
 			fmt.Println(printConfigT(t, 2))
@@ -90,8 +90,8 @@ func printConfig(c *hclconfig.Config) {
 
 		case "output":
 			t := r.(*types.Output)
-			fmt.Printf("  Postgres %s\n", t.Name)
-			fmt.Printf("  Module %s\n", t.Module)
+			fmt.Printf("  Postgres %s\n", t.ResourceName)
+			fmt.Printf("  Module %s\n", t.ResourceModule)
 			fmt.Printf("  --- Value: %s\n", t.Value)
 		}
 
@@ -106,9 +106,9 @@ func printConfigT(t *Config, indent int) string {
 		pad += " "
 	}
 
-	fmt.Fprintf(str, "%sConfig %s\n", pad, t.Name)
-	fmt.Fprintf(str, "%sModule %s\n", pad, t.Module)
-	fmt.Fprintf(str, "%s--- ID: %s\n", pad, t.ID)
+	fmt.Fprintf(str, "%sConfig %s\n", pad, t.ResourceName)
+	fmt.Fprintf(str, "%sModule %s\n", pad, t.ResourceModule)
+	fmt.Fprintf(str, "%s--- ID: %s\n", pad, t.ResourceID)
 	fmt.Fprintf(str, "%s--- DBConnectionString: %s\n", pad, t.DBConnectionString)
 	fmt.Fprintf(str, "%s--- Timeouts\n", pad)
 	fmt.Fprintf(str, "%s------ Connection: %d\n", pad, t.Timeouts.Connection)
@@ -133,8 +133,8 @@ func printPostgres(p *PostgreSQL, indent int) string {
 		pad += " "
 	}
 
-	fmt.Fprintf(str, "%sPostgres %s\n", pad, p.Name)
-	fmt.Fprintf(str, "%sModule %s\n", pad, p.Module)
+	fmt.Fprintf(str, "%sPostgres %s\n", pad, p.ResourceName)
+	fmt.Fprintf(str, "%sModule %s\n", pad, p.ResourceModule)
 	fmt.Fprintf(str, "%s--- Location: %s\n", pad, p.Location)
 	fmt.Fprintf(str, "%s--- Port: %d\n", pad, p.Port)
 	fmt.Fprintf(str, "%s--- DBName: %s\n", pad, p.DBName)

--- a/test_fixtures/disabled/modules/resources.hcl
+++ b/test_fixtures/disabled/modules/resources.hcl
@@ -13,7 +13,7 @@ resource "container" "enabled" {
   command = ["consul", "agent", "-dev", "-client", "0.0.0.0"]
 
   network {
-    name       = resource.network.onprem.name
+    name       = resource.network.onprem.resource_name
     ip_address = "10.6.0.200"
   }
 

--- a/test_fixtures/disabled/modules/sub-modules/resources.hcl
+++ b/test_fixtures/disabled/modules/sub-modules/resources.hcl
@@ -6,7 +6,7 @@ resource "container" "enabled" {
   command = ["consul", "agent", "-dev", "-client", "0.0.0.0"]
 
   network {
-    name       = resource.network.onprem.name
+    name       = resource.network.onprem.resource_name
     ip_address = "10.6.0.200"
   }
 

--- a/test_fixtures/functions/default.hcl
+++ b/test_fixtures/functions/default.hcl
@@ -45,7 +45,7 @@ resource "container" "default" {
     })
   }
 
-  dns = resource.container.with_networks.created_network_map != null ? values(resource.container.with_networks.created_network_map).*.name : []
+  dns = resource.container.with_networks.created_network_map != null ? values(resource.container.with_networks.created_network_map).*.resource_name : []
 
   entrypoint = values({
     "one" = { "id" = "123" }

--- a/test_fixtures/invalid/no_name.hcl
+++ b/test_fixtures/invalid/no_name.hcl
@@ -2,7 +2,7 @@ resource "container" {
   command = ["consul", "agent", "-dev", "-client", "0.0.0.0"]
 
   network {
-    name       = resource.network.onprem.name
+    name       = resource.network.onprem.resource_name
     ip_address = "10.6.0.200"
   }
 

--- a/test_fixtures/invalid/no_resource.hcl
+++ b/test_fixtures/invalid/no_resource.hcl
@@ -2,7 +2,7 @@ container "mine" {
   command = ["consul", "agent", "-dev", "-client", "0.0.0.0"]
 
   network {
-    name       = resource.network.onprem.name
+    name       = resource.network.onprem.resource_name
     ip_address = "10.6.0.200"
   }
 

--- a/test_fixtures/invalid/no_type.hcl
+++ b/test_fixtures/invalid/no_type.hcl
@@ -2,7 +2,7 @@ resource "myresource" {
   command = ["consul", "agent", "-dev", "-client", "0.0.0.0"]
 
   network {
-    name       = resource.network.onprem.name
+    name       = resource.network.onprem.resource_name
     ip_address = "10.6.0.200"
   }
 

--- a/test_fixtures/locals/locals.hcl
+++ b/test_fixtures/locals/locals.hcl
@@ -20,13 +20,13 @@ resource "container" "consul" {
 local "test" {
 
   //value = resource.container.consul.name
-  value = resource.container.consul.name == "consul" ? "yes" : "no"
+  value = resource.container.consul.resource_name == "consul" ? "yes" : "no"
 }
 
 resource "template" "consul_config_update" {
   disabled = false
 
-  source = resource.container.consul.name == "consul" ? "yes" : "no"
+  source = resource.container.consul.resource_name == "consul" ? "yes" : "no"
 
   destination = "./consul.hcl"
 

--- a/test_fixtures/simple/container.hcl
+++ b/test_fixtures/simple/container.hcl
@@ -50,20 +50,20 @@ resource "template" "consul_config_update" {
 resource "container" "base" {
   // ensure that arrays can also have interpolation
   entrypoint = [
-    resource.network.onprem.id
+    resource.network.onprem.resource_id
   ]
 
   command = ["consul", "agent", "-dev", "-client", "0.0.0.0"]
 
   network {
     id         = 1
-    name       = resource.network.onprem.name
+    name       = resource.network.onprem.resource_name
     ip_address = "10.6.0.200"
   }
 
   network {
     id         = 2
-    name       = resource.network.onprem.name
+    name       = resource.network.onprem.resource_name
     ip_address = "10.6.0.201"
   }
 
@@ -80,7 +80,7 @@ resource "container" "consul" {
   command = ["consul", "agent", "-dev", "-client", "0.0.0.0"]
 
   network {
-    name       = resource.network.onprem.name
+    name       = resource.network.onprem.resource_name
     ip_address = "10.6.0.200"
     id         = resource.container.base.network[0].id
   }
@@ -121,7 +121,7 @@ resource "container" "consul" {
 
   volume {
     source      = "."
-    destination = "/test2/${env(resource.template.consul_config.name)}"
+    destination = "/test2/${env(resource.template.consul_config.resource_name)}"
   }
 }
 

--- a/test_fixtures/single/container.hcl
+++ b/test_fixtures/single/container.hcl
@@ -11,7 +11,7 @@ resource "container" "consul" {
   command = ["consul", "agent", "-dev", "-client", "0.0.0.0"]
 
   network {
-    name       = resource.network.onprem.name
+    name       = resource.network.onprem.resource_name
     ip_address = "10.6.0.200"
   }
 
@@ -29,7 +29,7 @@ resource "container" "consul" {
 }
 
 output "container_name" {
-  value = resource.container.consul.name
+  value = resource.container.consul.resource_name
 }
 
 output "container_resources_cpu" {
@@ -45,7 +45,7 @@ output "combined_list" {
 
 output "combined_map" {
   value = {
-    name = resource.container.consul.name
+    name = resource.container.consul.resource_name
     cpu  = resource.container.consul.resources.cpu
   }
 }

--- a/test_fixtures/structs/container.go
+++ b/test_fixtures/structs/container.go
@@ -88,7 +88,7 @@ type Build struct {
 // here as they are overwritten when the resource is processed by the dag
 // ResourceMetadata properties can be set
 func (c *Container) Parse(conf types.Findable) error {
-	c.Properties["status"] = "something"
+	c.ResourceProperties["status"] = "something"
 	return nil
 }
 

--- a/types/default.go
+++ b/types/default.go
@@ -37,9 +37,9 @@ func (r RegisteredTypes) CreateResource(resourceType, resourceName string) (Reso
 		ptr := reflect.New(reflect.TypeOf(t).Elem())
 
 		res := ptr.Interface().(Resource)
-		res.Metadata().Name = resourceName
-		res.Metadata().Type = resourceType
-		res.Metadata().Properties = map[string]interface{}{}
+		res.Metadata().ResourceName = resourceName
+		res.Metadata().ResourceType = resourceType
+		res.Metadata().ResourceProperties = map[string]interface{}{}
 
 		return res, nil
 	}

--- a/types/default_test.go
+++ b/types/default_test.go
@@ -29,6 +29,6 @@ func TestCreateResourceCreatesType(t *testing.T) {
 	require.NoError(t, e)
 	require.NotNil(t, r)
 
-	require.Equal(t, r.Metadata().Type, TypeVariable)
-	require.Equal(t, r.Metadata().Name, "test")
+	require.Equal(t, r.Metadata().ResourceType, TypeVariable)
+	require.Equal(t, r.Metadata().ResourceName, "test")
 }

--- a/types/fqdn.go
+++ b/types/fqdn.go
@@ -163,9 +163,9 @@ func (f *ResourceFQRN) AppendParentModule(parent string) ResourceFQRN {
 // FQDNFromResource returns the ResourceFQDN for the given Resource
 func FQDNFromResource(r Resource) *ResourceFQRN {
 	return &ResourceFQRN{
-		Module:   r.Metadata().Module,
-		Resource: r.Metadata().Name,
-		Type:     r.Metadata().Type,
+		Module:   r.Metadata().ResourceModule,
+		Resource: r.Metadata().ResourceName,
+		Type:     r.Metadata().ResourceType,
 	}
 }
 

--- a/types/fqdn_test.go
+++ b/types/fqdn_test.go
@@ -251,7 +251,7 @@ func TestFQRNFromResourceReturnsCorrectData(t *testing.T) {
 	r, err := dt.CreateResource(typeTestContainer, "mytest")
 	require.NoError(t, err)
 
-	r.Metadata().Module = "mymodule"
+	r.Metadata().ResourceModule = "mymodule"
 
 	fqrn := FQDNFromResource(r)
 
@@ -287,7 +287,7 @@ func TestFQRNFromVariableInModuleReturnsCorrectData(t *testing.T) {
 	r, err := dt.CreateResource(TypeVariable, "mytest")
 	require.NoError(t, err)
 
-	r.Metadata().Module = "mymodule"
+	r.Metadata().ResourceModule = "mymodule"
 
 	fqrn := FQDNFromResource(r)
 

--- a/types/resource.go
+++ b/types/resource.go
@@ -52,37 +52,37 @@ type ResourceMetadata struct {
 	// ID is the unique id for the resource
 	// this follows the convention module_name.resource_name
 	// i.e module.module1.module2.resource.container.mine
-	ID string `hcl:"id,optional" json:"id"`
+	ResourceID string `hcl:"resource_id,optional" json:"resource_id"`
 
 	// Name is the name of the resource
 	// this is an internal property that is set from the stanza label
-	Name string `hcl:"name,optional" json:"name"`
+	ResourceName string `hcl:"resource_name,optional" json:"resource_name"`
 
 	// Type is the type of resource, this is the text representation of the golang type
 	// this is an internal property that can not be set with hcl
-	Type string `hcl:"type,optional" json:"type"`
+	ResourceType string `hcl:"resource_type,optional" json:"resource_type"`
 
 	// Module is the name of the module if a resource has been loaded from a module
 	// this is an internal property that can not be set with hcl
-	Module string `hcl:"module,optional" json:"module,omitempty"`
+	ResourceModule string `hcl:"resource_module,optional" json:"resource_module,omitempty"`
 
 	// File is the absolute path of the file where the resource is defined
 	// this is an internal property that can not be set with hcl
-	SourceFile string `hcl:"source_file,optional" json:"source_file"`
+	ResourceFile string `hcl:"resource_file,optional" json:"resource_file"`
 
 	// Line is the starting line number where the resource is located in the
 	// file from where it was originally parsed
-	SourceLine int `hcl:"source_line,optional" json:"source_line"`
+	ResourceLine int `hcl:"resource_line,optional" json:"resource_line"`
 
 	// Column is the starting column number where the resource is located in the
 	// file from where it was originally parsed
-	SourceColumn int `hcl:"source_column,optional" json:"source_column"`
+	ResourceColumn int `hcl:"resource_column,optional" json:"resource_column"`
 
 	// Checksum is the md5 hash of the resource
-	SourceChecksum Checksum `hcl:"source_checksum,optional" json:"source_checksum"`
+	ResourceChecksum Checksum `hcl:"resource_checksum,optional" json:"resource_checksum"`
 
 	// Properties holds a collection that can be used to store adhoc data
-	Properties map[string]interface{} `json:"properties,omitempty"`
+	ResourceProperties map[string]interface{} `json:"resource_properties,omitempty"`
 
 	// Linked resources which must be set before this config can be processed
 	// this is an internal property that can not be set with hcl

--- a/utils_test.go
+++ b/utils_test.go
@@ -35,7 +35,7 @@ var container = `resource "container" "consul" {
   command = ["consul", "agent", "-dev", "-client", "0.0.0.0"]
 
   network {
-    name       = resource.network.onprem.name
+    name       = resource.network.onprem.resource_name
     ip_address = "10.6.0.200"
   }
 


### PR DESCRIPTION
Renaming all fields in `Resource` that are not directly user exposed to include a prefix of `Resource` in the struct and `resource_` in the annotations.

This prevents unclear errors when a user defines a field that has an overlapping name such as `type`.