### PR TITLE
Enable disabled to be set by an interpolated value or from a module value.

### DIFF
--- a/config.go
+++ b/config.go
@@ -102,7 +102,7 @@ func (c *Config) findResource(path string) (types.Resource, error) {
 		}
 	}
 
-	return nil, ResourceNotFoundError{path}
+	return nil, ResourceNotFoundError{fqdn.StringWithoutAttribute()}
 }
 
 func (c *Config) FindRelativeResource(path string, parentModule string) (types.Resource, error) {

--- a/dag.go
+++ b/dag.go
@@ -168,104 +168,46 @@ func createCallback(c *Config, wf WalkCallback) func(v dag.Vertex) (diags dag.Di
 		// first we need to check if the resource is disabled
 		// this might be set by an interpolated value
 		// if this is disabled we ignore the resource
+		//
+		// This expression could be a reference to another resource or it could be a
+		// function or a conditional statement. We need to evaluate the expression
+		// to determine if the resource should be disabled
 		if attr, ok := bdy.Attributes["disabled"]; ok {
 			expr, err := processExpr(attr.Expr)
 
+			// need to handle this error
 			if err != nil {
-				panic(err)
+				pe := &errors.ParserError{}
+				pe.Filename = r.Metadata().File
+				pe.Line = r.Metadata().Line
+				pe.Column = r.Metadata().Column
+				pe.Message = fmt.Sprintf(`unable to process disabled expression: %s`, err)
+				pe.Level = errors.ParserErrorLevelError
+
+				return diags.Append(pe)
 			}
 
 			if len(expr) > 0 {
-				// This expression could be a reference to another resource or it could be a
-				// function or a conditional statement. We need to evaluate the expression
-				// to determine if the resource should be disabled
+				// first we need to build the context for the expression
+				err := setContextVariablesFromList(c, r, expr, ctx)
+				if err != nil {
+					return diags.Append(err)
+				}
 
-				//l, err := c.FindRelativeResource(expr[0], r.Metadata().Module)
-				//if err != nil {
-				//	pe := &errors.ParserError{}
-				//	pe.Filename = r.Metadata().File
-				//	pe.Line = r.Metadata().Line
-				//	pe.Column = r.Metadata().Column
-				//	pe.Message = fmt.Sprintf(`unable to find dependent resource "%s" %s`, v, err)
-				//	pe.Level = errors.ParserErrorLevelError
-
-				//	return diags.Append(pe)
-				//}
-
-			}
-
-		}
-
-		// attempt to set the values in the resource links to the resource attribute
-		// all linked values should now have been processed as the graph
-		// will have handled them first
-		for _, v := range r.Metadata().Links {
-			fqrn, err := resources.ParseFQRN(v)
-			if err != nil {
-				pe := &errors.ParserError{}
-				pe.Filename = r.Metadata().File
-				pe.Line = r.Metadata().Line
-				pe.Column = r.Metadata().Column
-				pe.Message = fmt.Sprintf("error parsing resource link %s", err)
-				pe.Level = errors.ParserErrorLevelError
-
-				return diags.Append(pe)
-			}
-
-			// get the value from the linked resource
-			l, err := c.FindRelativeResource(v, r.Metadata().Module)
-			if err != nil {
-				pe := &errors.ParserError{}
-				pe.Filename = r.Metadata().File
-				pe.Line = r.Metadata().Line
-				pe.Column = r.Metadata().Column
-				pe.Message = fmt.Sprintf(`unable to find dependent resource "%s" %s`, v, err)
-				pe.Level = errors.ParserErrorLevelError
-
-				return diags.Append(pe)
-			}
-
-			var ctyRes cty.Value
-
-			// once we have found a resource convert it to a cty type and then
-			// set it on the context
-			switch l.Metadata().Type {
-			case resources.TypeLocal:
-				loc := l.(*resources.Local)
-				ctyRes = loc.CtyValue
-			case resources.TypeOutput:
-				out := l.(*resources.Output)
-				ctyRes = out.CtyValue
-			default:
-				ctyRes, err = convert.GoToCtyValue(l)
-			}
-
-			if err != nil {
-				pe := &errors.ParserError{}
-				pe.Filename = r.Metadata().File
-				pe.Line = r.Metadata().Line
-				pe.Column = r.Metadata().Column
-				pe.Message = fmt.Sprintf(`unable to convert reference %s to context variable: %s`, v, err)
-				pe.Level = errors.ParserErrorLevelError
-
-				return diags.Append(pe)
-			}
-
-			// remove the attributes and to get a pure resource ref
-			fqrn.Attribute = ""
-
-			err = setContextVariableFromPath(ctx, fqrn.String(), ctyRes)
-			if err != nil {
-				pe := &errors.ParserError{}
-				pe.Filename = r.Metadata().File
-				pe.Line = r.Metadata().Line
-				pe.Column = r.Metadata().Column
-				pe.Message = fmt.Sprintf(`unable to set context variable: %s`, err)
-				pe.Level = errors.ParserErrorLevelError
-
-				return diags.Append(pe)
+				// now we need to evaluate the expression
+				var isDisabled bool
+				gohcl.DecodeExpression(attr.Expr, ctx, &isDisabled)
+				r.SetDisabled(isDisabled)
 			}
 		}
+
+		// if the resource is disabled we need to skip the resource
+		if r.GetDisabled() {
+			return nil
+		}
+
+		// set the context variables from the linked resources
+		setContextVariablesFromList(c, r, r.Metadata().Links, ctx)
 
 		// Process the raw resource now we have the context from the linked
 		// resources
@@ -385,4 +327,84 @@ func createCallback(c *Config, wf WalkCallback) func(v dag.Vertex) (diags dag.Di
 
 		return nil
 	}
+}
+
+// setContextVariablesFromList sets the context variables from a list of resource links
+//
+// for example: given the values ["module.module1.module2.resource.container.mine.id"]
+// the context variable "module.module1.module2.resource.container.mine.id" will be set to the
+// value defined by the resource of type container with the name mine and the attribute id
+func setContextVariablesFromList(c *Config, r types.Resource, values []string, ctx *hcl.EvalContext) *errors.ParserError {
+	// attempt to set the values in the resource links to the resource attribute
+	// all linked values should now have been processed as the graph
+	// will have handled them first
+	for _, v := range values {
+		fqrn, err := resources.ParseFQRN(v)
+		if err != nil {
+			pe := &errors.ParserError{}
+			pe.Filename = r.Metadata().File
+			pe.Line = r.Metadata().Line
+			pe.Column = r.Metadata().Column
+			pe.Message = fmt.Sprintf("error parsing resource link %s", err)
+			pe.Level = errors.ParserErrorLevelError
+
+			return pe
+		}
+
+		// get the value from the linked resource
+		l, err := c.FindRelativeResource(v, r.Metadata().Module)
+		if err != nil {
+			pe := &errors.ParserError{}
+			pe.Filename = r.Metadata().File
+			pe.Line = r.Metadata().Line
+			pe.Column = r.Metadata().Column
+			pe.Message = fmt.Sprintf(`unable to find dependent resource "%s" %s`, v, err)
+			pe.Level = errors.ParserErrorLevelError
+
+			return pe
+		}
+
+		var ctyRes cty.Value
+
+		// once we have found a resource convert it to a cty type and then
+		// set it on the context
+		switch l.Metadata().Type {
+		case resources.TypeLocal:
+			loc := l.(*resources.Local)
+			ctyRes = loc.CtyValue
+		case resources.TypeOutput:
+			out := l.(*resources.Output)
+			ctyRes = out.CtyValue
+		default:
+			ctyRes, err = convert.GoToCtyValue(l)
+		}
+
+		if err != nil {
+			pe := &errors.ParserError{}
+			pe.Filename = r.Metadata().File
+			pe.Line = r.Metadata().Line
+			pe.Column = r.Metadata().Column
+			pe.Message = fmt.Sprintf(`unable to convert reference %s to context variable: %s`, v, err)
+			pe.Level = errors.ParserErrorLevelError
+
+			return pe
+		}
+
+		// remove the attributes and to get a pure resource ref
+		fqrn.Attribute = ""
+
+		err = setContextVariableFromPath(ctx, fqrn.String(), ctyRes)
+		if err != nil {
+			pe := &errors.ParserError{}
+			pe.Filename = r.Metadata().File
+			pe.Line = r.Metadata().Line
+			pe.Column = r.Metadata().Column
+			pe.Message = fmt.Sprintf(`unable to set context variable: %s`, err)
+			pe.Level = errors.ParserErrorLevelError
+
+			return pe
+		}
+	}
+
+	return nil
 }

--- a/dag.go
+++ b/dag.go
@@ -42,18 +42,6 @@ func doYaLikeDAGs(c *Config) (*dag.AcyclicGraph, error) {
 			continue
 		}
 
-		// we might not yet know if the resource is disabled, this could be due
-		// to the value being set from a variable or an interpolated value
-
-		// if disabled ignore any dependencies
-		if resource.GetDisabled() {
-			// add all disabled resources to the root
-			//fmt.Println("connect", "root", "to", resource.Metadata().ID)
-
-			graph.Connect(dag.BasicEdge(root, resource))
-			continue
-		}
-
 		// use a map to keep a unique list
 		dependencies := map[types.Resource]bool{}
 
@@ -177,7 +165,7 @@ func createCallback(c *Config, wf WalkCallback) func(v dag.Vertex) (diags dag.Di
 		}
 
 		// if this is the root module or is disabled skip or is a variable
-		if (r.Metadata().Type == resources.TypeRoot) || r.GetDisabled() {
+		if r.Metadata().Type == resources.TypeRoot {
 			return nil
 		}
 
@@ -297,8 +285,9 @@ func createCallback(c *Config, wf WalkCallback) func(v dag.Vertex) (diags dag.Di
 			return diags.Append(pe)
 		}
 
-		// if the type is a module the potentially we only just found out that we should be
+		// if the type is a module then potentially we only just found out that we should be
 		// disabled
+
 		// as an additional check, set all module resources to disabled if the module is disabled
 		if r.GetDisabled() && r.Metadata().Type == resources.TypeModule {
 			// find all dependent resources

--- a/functions_test.go
+++ b/functions_test.go
@@ -173,8 +173,6 @@ func TestParseProcessesDefaultFunctionsWithFile(t *testing.T) {
 		os.Unsetenv("MYENV")
 	})
 
-	home, _ := os.UserHomeDir()
-
 	p := setupParser(t)
 	c, err := p.ParseFile(absoluteFolderPath)
 	require.NoError(t, err)
@@ -183,6 +181,8 @@ func TestParseProcessesDefaultFunctionsWithFile(t *testing.T) {
 	require.NoError(t, err)
 
 	cont := r.(*structs.Container)
+
+	home, _ := os.UserHomeDir()
 
 	require.Equal(t, "3", cont.Env["len_string"])
 	require.Equal(t, "2", cont.Env["len_collection"])
@@ -210,8 +210,6 @@ func TestParseProcessesDefaultFunctionsWithDirectory(t *testing.T) {
 		os.Unsetenv("MYENV")
 	})
 
-	home, _ := os.UserHomeDir()
-
 	p := setupParser(t)
 	p.RegisterFunction("constant_number", func() (int, error) { return 42, nil })
 
@@ -222,6 +220,8 @@ func TestParseProcessesDefaultFunctionsWithDirectory(t *testing.T) {
 	require.NoError(t, err)
 
 	cont := r.(*structs.Container)
+
+	home, _ := os.UserHomeDir()
 
 	require.Equal(t, "3", cont.Env["len_string"])
 	require.Equal(t, "2", cont.Env["len_collection"])

--- a/parse_test.go
+++ b/parse_test.go
@@ -363,7 +363,7 @@ func TestParseModuleCreatesResources(t *testing.T) {
 	c, err := p.ParseFile(absoluteFolderPath)
 	require.NoError(t, err)
 
-	require.Len(t, c.Resources, 35)
+	require.Len(t, c.Resources, 39)
 
 	// check resource has been created
 	cont, err := c.FindResource("module.consul_1.resource.container.consul")
@@ -417,7 +417,7 @@ func TestParseModuleCreatesOutputs(t *testing.T) {
 	c, err := p.ParseFile(absoluteFolderPath)
 	require.NoError(t, err)
 
-	require.Len(t, c.Resources, 35)
+	require.Len(t, c.Resources, 39)
 
 	cont, err := c.FindResource("output.module1_container_resources_cpu")
 	require.NoError(t, err)

--- a/parse_test.go
+++ b/parse_test.go
@@ -497,11 +497,16 @@ func TestModuleDisabledCanBeOverriden(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	callbackMutext := sync.Mutex{}
+
 	calls := []string{}
 	o := DefaultOptions()
 	o.Callback = func(r types.Resource) error {
+		callbackMutext.Lock()
 		log.Printf("callback: %s", r.Metadata().ID)
 		calls = append(calls, r.Metadata().ID)
+
+		callbackMutext.Unlock()
 
 		return nil
 	}

--- a/parse_test.go
+++ b/parse_test.go
@@ -591,7 +591,7 @@ func TestParseDoesNotProcessDisabledResources(t *testing.T) {
 
 	c, err := p.ParseFile(absoluteFolderPath)
 	require.NoError(t, err)
-	require.Equal(t, 3, c.ResourceCount())
+	require.Equal(t, 4, c.ResourceCount())
 
 	r, err := c.FindResource("resource.container.disabled_value")
 	require.NoError(t, err)
@@ -845,8 +845,8 @@ func TestParserStopsParseOnCallbackError(t *testing.T) {
 	_, err = p.ParseFile(absoluteFolderPath)
 	require.Error(t, err)
 
-	// only 13 of the resources and variables should be created, none of the descendants of base
-	require.Len(t, calls, 13)
+	// only 16 of the resources and variables should be created, none of the descendants of base
+	require.Len(t, calls, 16)
 	require.NotContains(t, "resource.module.consul_1", calls)
 }
 

--- a/parser.go
+++ b/parser.go
@@ -544,29 +544,6 @@ func (p *Parser) parseResourcesInFile(ctx *hcl.EvalContext, file string, c *Conf
 	return nil
 }
 
-func setDisabled(ctx *hcl.EvalContext, r types.Resource, b *hclsyntax.Body, parentDisabled bool) error {
-	if b == nil {
-		return nil
-	}
-
-	if parentDisabled {
-		r.SetDisabled(true)
-		return nil
-	}
-
-	if attr, ok := b.Attributes["disabled"]; ok {
-
-		disabled, diags := attr.Expr.Value(ctx)
-		if diags.HasErrors() {
-			return fmt.Errorf("unable to read source from module: %s", diags.Error())
-		}
-
-		r.SetDisabled(disabled.True())
-	}
-
-	return nil
-}
-
 func setDependsOn(ctx *hcl.EvalContext, r types.Resource, b *hclsyntax.Body, dependsOn []string) error {
 	for _, d := range dependsOn {
 		r.AddDependency(d)
@@ -636,8 +613,6 @@ func (p *Parser) parseModule(ctx *hcl.EvalContext, c *Config, file string, b *hc
 
 		return []error{de}
 	}
-
-	setDisabled(ctx, rt, b.Body, false)
 
 	derr := setDependsOn(ctx, rt, b.Body, dependsOn)
 	if derr != nil {
@@ -835,9 +810,6 @@ func (p *Parser) parseModule(ctx *hcl.EvalContext, c *Config, file string, b *hc
 			panic("no body found for resource")
 		}
 
-		// set disabled
-		setDisabled(ctx, r, bdy, rt.GetDisabled())
-
 		// depends on is a property of the embedded type we need to set this manually
 		err = setDependsOn(ctx, rt, b.Body, dependsOn)
 		if err != nil {
@@ -1011,9 +983,6 @@ func (p *Parser) parseResource(ctx *hcl.EvalContext, c *Config, file string, b *
 			rt.(*resources.Output).Description = desc.AsString()
 		}
 	}
-
-	// disabled is a property of the embedded type we need to add this manually
-	setDisabled(ctx, rt, b.Body, disabled)
 
 	// depends on is a property of the embedded type we need to set this manually
 	err = setDependsOn(ctx, rt, b.Body, dependsOn)

--- a/resources/fqrn.go
+++ b/resources/fqrn.go
@@ -196,3 +196,24 @@ func (f FQRN) String() string {
 
 	return fmt.Sprintf("%sresource.%s.%s%s", modulePart, f.Type, f.Resource, attrPart)
 }
+
+func (f FQRN) StringWithoutAttribute() string {
+	modulePart := ""
+	if f.Module != "" {
+		modulePart = fmt.Sprintf("module.%s.", f.Module)
+	}
+
+	if f.Type == TypeOutput || f.Type == TypeLocal || f.Type == TypeVariable {
+		return fmt.Sprintf("%s%s.%s", modulePart, f.Type, f.Resource)
+	}
+
+	if f.Type == TypeModule {
+		if f.Module == "" {
+			return fmt.Sprintf("module.%s", f.Resource)
+		}
+
+		return fmt.Sprintf("%s%s", modulePart, f.Resource)
+	}
+
+	return fmt.Sprintf("%sresource.%s.%s", modulePart, f.Type, f.Resource)
+}

--- a/test_fixtures/disabled/disabled.hcl
+++ b/test_fixtures/disabled/disabled.hcl
@@ -47,7 +47,7 @@ resource "container" "disabled_variable" {
 
 ## This resource sets disabled based on another resource
 resource "container" "disabled_variable_deps" {
-  disabled = resource.container.disabled_variable.meta.disabled
+  disabled = resource.container.disabled_variable.disabled
 
   command = ["consul", "agent", "-dev", "-client", "0.0.0.0"]
 

--- a/test_fixtures/disabled/disabled.hcl
+++ b/test_fixtures/disabled/disabled.hcl
@@ -44,3 +44,23 @@ resource "container" "disabled_variable" {
     cpu_pin = [1]
   }
 }
+
+## This resource sets disabled based on another resource
+resource "container" "disabled_variable_deps" {
+  disabled = resource.container.disabled_variable.meta.disabled
+
+  command = ["consul", "agent", "-dev", "-client", "0.0.0.0"]
+
+  // if not removed, will fail due to dependency violation
+  //network {
+  //  name       = resource.network.onprem.name
+  //  ip_address = "10.6.0.200"
+  //}
+
+  dns = ["a", "b", "c"]
+
+  resources {
+    memory  = 1024
+    cpu_pin = [1]
+  }
+}

--- a/test_fixtures/modules/modules.hcl
+++ b/test_fixtures/modules/modules.hcl
@@ -30,6 +30,7 @@ module "consul_2" {
   source = "../single"
   variables = {
     cpu_resources = variable.default_cpu
+    enabled       = true
   }
 }
 

--- a/test_fixtures/single/container.hcl
+++ b/test_fixtures/single/container.hcl
@@ -6,8 +6,11 @@ resource "network" "onprem" {
   subnet = "10.6.0.0/16"
 }
 
-resource "container" "consul" {
+variable "enabled" {
+  default = false
+}
 
+resource "container" "consul" {
   command = ["consul", "agent", "-dev", "-client", "0.0.0.0"]
 
   network {
@@ -28,8 +31,12 @@ resource "container" "consul" {
 
 }
 
+resource "container" "sidecar" {
+  disabled = !variable.enabled
+}
+
 output "container_name" {
-  value = resource.container.consul.meta.name
+  value       = resource.container.consul.meta.name
   description = "This is the name of the container"
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestReadResourceFromFileAtLocation(t *testing.T) {
-	c, err := ReadFileLocation("./test_fixtures/single/container.hcl", 9, 1, 29, 2)
+	c, err := ReadFileLocation("./test_fixtures/single/container.hcl", 13, 1, 32, 2)
 	require.NoError(t, err)
 
 	// check the contents
@@ -15,7 +15,7 @@ func TestReadResourceFromFileAtLocation(t *testing.T) {
 }
 
 func TestLineFromFileAtLocation(t *testing.T) {
-	c, err := ReadFileLocation("./test_fixtures/single/container.hcl", 9, 1, 9, 30)
+	c, err := ReadFileLocation("./test_fixtures/single/container.hcl", 13, 1, 13, 30)
 	require.NoError(t, err)
 
 	// check the contents
@@ -31,7 +31,6 @@ func TestCalculatesHashFromString(t *testing.T) {
 var singleLine = `resource "container" "consul"`
 
 var container = `resource "container" "consul" {
-
   command = ["consul", "agent", "-dev", "-client", "0.0.0.0"]
 
   network {


### PR DESCRIPTION
Previously if a resource had disabled set by using a variable:

```hcl
variable "disabled" {
  value = true
}

resource "test" "a" {
  disabled = variable.disabled
}
```

When that variable was overridden in a module

```hcl
module "a"
  variables = {
    disabled = false
  }
```

The original value of the variable would be used as disabled was calculated before evaluating the context.

As a bonus effect, it is now possible to set the value of disabled using an interpolated value from another resource or by using a function.

```hcl
resource "test" "a" {
  disabled = resource.test.b.networkcount > 2 ? true : false
}
```