### PR TITLE
Improve error messages

### DIFF
--- a/errors/config_error_test.go
+++ b/errors/config_error_test.go
@@ -34,5 +34,5 @@ func TestErrorReturnsConcatonatedString(t *testing.T) {
 	ce.AppendError(&ParserError{Message: "boom"})
 	ce.AppendError(&ParserError{Message: "bang"})
 
-	require.Equal(t, "Error:\n  boom\n\n  :0,0\n\nError:\n  bang\n\n  :0,0\n", ce.Error())
+	require.Equal(t, "Error:\n  boom\n\n :0,0-0\n\nError:\n  bang\n\n :0,0-0\n", ce.Error())
 }

--- a/errors/parser_error.go
+++ b/errors/parser_error.go
@@ -3,6 +3,8 @@ package errors
 import (
 	"fmt"
 	"os"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/mitchellh/go-wordwrap"
@@ -31,20 +33,50 @@ func (p *ParserError) Error() string {
 		err.WriteString("  " + l + "\n")
 	}
 
+	// <error>: <filename>:<line>,<from-column>-<to-column>: <error details>
+	// e.g. `unable to decode body: /exec_module/module/module.hcl:9,3-8: Unsupported argument;
+	// An argument named "image" is not expected here., and 1 other diagnostic(s)`
+	msgRegex, _ := regexp.Compile(`^(?P<error>.*): (?P<file>.*):(?P<line>\d+),(?P<start>\d+)-(?P<end>\d+): (?P<details>.*)$`)
+	matches := msgRegex.FindStringSubmatch(p.Message)
+
+	errFile := p.Filename
+	errLine := p.Line
+	errStart := p.Column
+	errEnd := p.Column
+
+	if len(matches) > 0 {
+		parts := make(map[string]string)
+		for i, name := range msgRegex.SubexpNames() {
+			if i != 0 && name != "" {
+				parts[name] = matches[i]
+			}
+		}
+
+		// We can use this later to display the error differently if we want to.
+		// errMsg := parts["error"]
+		errFile = parts["file"]
+		errLine, _ = strconv.Atoi(parts["line"])
+		errStart, _ = strconv.Atoi(parts["start"])
+		errEnd, _ = strconv.Atoi(parts["end"])
+	}
+
 	err.WriteString("\n")
 
-	err.WriteString("  " + fmt.Sprintf("%s:%d,%d\n", p.Filename, p.Line, p.Column))
+	// err.WriteString("  " + fmt.Sprintf("%s:%d,%d\n", p.Filename, p.Line, p.Column))
+	err.WriteString(" " + fmt.Sprintf("%s:%d,%d-%d\n", errFile, errLine, errStart, errEnd))
+
 	// process the file
-	file, _ := os.ReadFile(wordwrap.WrapString(p.Filename, 80))
+	// file, _ := os.ReadFile(wordwrap.WrapString(p.Filename, 80))
+	file, _ := os.ReadFile(wordwrap.WrapString(errFile, 80))
 
 	lines := strings.Split(string(file), "\n")
 
-	startLine := p.Line - 3
+	startLine := errLine - 3
 	if startLine < 0 {
 		startLine = 0
 	}
 
-	endLine := p.Line + 2
+	endLine := errLine + 2
 	if endLine >= len(lines) {
 		endLine = len(lines) - 1
 	}
@@ -53,14 +85,14 @@ func (p *ParserError) Error() string {
 		codeline := wordwrap.WrapString(lines[i], 70)
 		codelines := strings.Split(codeline, "\n")
 
-		if i == p.Line-1 {
+		if i == errLine-1 {
 			err.WriteString(fmt.Sprintf("\033[1m  %5d | %s\033[0m\n", i+1, codelines[0]))
 		} else {
 			err.WriteString(fmt.Sprintf("\033[2m  %5d | %s\033[0m\n", i+1, codelines[0]))
 		}
 
 		for _, l := range codelines[1:] {
-			if i == p.Line-1 {
+			if i == errLine-1 {
 				err.WriteString(fmt.Sprintf("\033[1m        : %s\033[0m\n", l))
 			} else {
 				err.WriteString(fmt.Sprintf("\033[2m        : %s\033[0m\n", l))

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/jumppad-labs/hclconfig
 
-go 1.22
-
-toolchain go1.22.2
+go 1.24
 
 require (
 	github.com/creasty/defaults v1.8.0
@@ -15,6 +13,7 @@ require (
 	github.com/silas/dag v0.0.0-20220518035006-a7e85ada93c5
 	github.com/stretchr/testify v1.9.0
 	github.com/zclconf/go-cty v1.15.0
+	golang.org/x/text v0.17.0
 )
 
 require (
@@ -60,7 +59,6 @@ require (
 	golang.org/x/oauth2 v0.22.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.23.0 // indirect
-	golang.org/x/text v0.17.0 // indirect
 	golang.org/x/time v0.6.0 // indirect
 	golang.org/x/tools v0.24.0 // indirect
 	google.golang.org/api v0.190.0 // indirect

--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -446,7 +446,7 @@ func ExampleLookup() {
 	// Output: 10
 }
 
-func ExampleCaseInsensitive() {
+func ExampleLookupStringI() {
 	type ExampleStruct struct {
 		SoftwareUpdated bool
 	}

--- a/parse_test.go
+++ b/parse_test.go
@@ -870,8 +870,8 @@ func TestParserStopsParseOnCallbackError(t *testing.T) {
 	_, err = p.ParseFile(absoluteFolderPath)
 	require.Error(t, err)
 
-	// only 16 of the resources and variables should be created, none of the descendants of base
-	require.Len(t, calls, 16)
+	// only 17 of the resources and variables should be created, none of the descendants of base
+	require.Len(t, calls, 17)
 	require.NotContains(t, "resource.module.consul_1", calls)
 }
 


### PR DESCRIPTION
Use supplied lines and columns to highlight code when supplied by the error so we point at the correct piece of config where the error actually occurred.