### PR TITLE
feat: Implement provider configuration system with full referenceability

### DIFF
--- a/dag.go
+++ b/dag.go
@@ -252,6 +252,7 @@ func destroyWalkCallback(registry *PluginRegistry, options *ParserOptions) func(
 		
 		// Skip builtin resource types that don't have providers
 		if r.Metadata().Type == resources.TypeVariable ||
+			r.Metadata().Type == resources.TypeProvider ||
 			r.Metadata().Type == resources.TypeOutput ||
 			r.Metadata().Type == resources.TypeLocal ||
 			r.Metadata().Type == resources.TypeModule ||

--- a/dag.go
+++ b/dag.go
@@ -265,7 +265,7 @@ func destroyWalkCallback(registry *PluginRegistry, options *ParserOptions) func(
 		}
 		
 		// Get the provider for this resource
-		adapter := registry.GetProvider(r)
+		adapter := registry.GetProviderAdapter(r)
 		if adapter == nil {
 			r.Metadata().Status = "destroy_failed"
 			pe := &errors.ParserError{}

--- a/dag_test.go
+++ b/dag_test.go
@@ -1,10 +1,12 @@
 package hclconfig
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/jumppad-labs/hclconfig/logger"
+	"github.com/jumppad-labs/hclconfig/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -72,4 +74,148 @@ func TestDoYaLikeDAGAddsDependencies(t *testing.T) {
 	require.Contains(t, list, network)
 	require.Contains(t, list, base)
 	require.Contains(t, list, template)
+}
+
+func TestProviderResourceDependency(t *testing.T) {
+	// Create temporary test file that shows provider-resource dependency
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.hcl")
+
+	hclContent := `
+variable "test_value" {
+  default = "from_variable"
+}
+
+provider "simple" {
+  source = "test/simple" 
+  version = "1.0.0"
+  
+  config {
+    value = variable.test_value
+    count = 42
+  }
+}
+
+resource "simple" "test" {
+  provider = "simple"
+  data = "hello world"
+}
+`
+
+	err := os.WriteFile(testFile, []byte(hclContent), 0644)
+	require.NoError(t, err)
+
+	// Create parser and register plugin
+	parser, _ := setupParser(t)
+	plugin := &SimplePlugin{}
+	err = parser.RegisterPlugin(plugin)
+	require.NoError(t, err)
+
+	// Register plugin source mapping
+	parser.GetPluginRegistry().RegisterPluginSource("test/simple", plugin)
+
+	// Parse the file (which includes processing and should handle dependencies)
+	config, err := parser.ParseFile(testFile)
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	// Verify provider was initialized properly
+	providerConfig, err := parser.GetPluginRegistry().GetProvider("simple")
+	require.NoError(t, err)
+	require.True(t, providerConfig.Initialized, "Provider should be initialized")
+	
+	// Verify config was resolved from variable
+	configValue, ok := providerConfig.Config.(*SimpleConfig)
+	require.True(t, ok, "Config should be of type SimpleConfig")
+	require.Equal(t, "from_variable", configValue.Value, "Value should be resolved from variable")
+	require.Equal(t, 42, configValue.Count, "Count should be set")
+
+	// Verify resource exists and was processed
+	var simpleResources []types.Resource
+	for _, r := range config.Resources {
+		if r.Metadata().Type == "simple" {
+			simpleResources = append(simpleResources, r)
+		}
+	}
+	require.Len(t, simpleResources, 1)
+	resource := simpleResources[0]
+	require.Equal(t, "simple", resource.Metadata().Type)
+	require.Equal(t, "test", resource.Metadata().Name)
+}
+
+func TestProviderResourceDependencyInDAG(t *testing.T) {
+	// Create temporary test file
+	tmpDir := t.TempDir() 
+	testFile := filepath.Join(tmpDir, "test.hcl")
+
+	hclContent := `
+variable "endpoint" {
+  default = "https://api.example.com"
+}
+
+provider "simple" {
+  source = "test/simple"
+  version = "1.0.0"
+  
+  config {
+    value = variable.endpoint
+    count = 100
+  }
+}
+
+resource "simple" "app1" {
+  provider = "simple"
+  data = "application 1"
+}
+
+resource "simple" "app2" {
+  provider = "simple" 
+  data = "application 2"
+}
+`
+
+	err := os.WriteFile(testFile, []byte(hclContent), 0644)
+	require.NoError(t, err)
+
+	// Create parser and register plugin
+	parser, _ := setupParser(t)
+	plugin := &SimplePlugin{}
+	err = parser.RegisterPlugin(plugin)
+	require.NoError(t, err)
+
+	// Register plugin source mapping  
+	parser.GetPluginRegistry().RegisterPluginSource("test/simple", plugin)
+
+	// Parse the file
+	config, err := parser.ParseFile(testFile)
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	// Verify that the provider was processed before the resources
+	// This test demonstrates that the DAG correctly handles provider dependencies
+	
+	// Check provider was initialized
+	providerConfig, err := parser.GetPluginRegistry().GetProvider("simple")
+	require.NoError(t, err)
+	require.True(t, providerConfig.Initialized, "Provider should be initialized")
+	
+	// Check config was resolved
+	configValue, ok := providerConfig.Config.(*SimpleConfig)
+	require.True(t, ok)
+	require.Equal(t, "https://api.example.com", configValue.Value)
+	require.Equal(t, 100, configValue.Count)
+
+	// Check both resources exist and were processed
+	var simpleResources []types.Resource
+	for _, r := range config.Resources {
+		if r.Metadata().Type == "simple" {
+			simpleResources = append(simpleResources, r)
+		}
+	}
+	require.Len(t, simpleResources, 2)
+	
+	// Both resources should have been processed (status should not be empty)
+	for _, r := range simpleResources {
+		require.NotEmpty(t, r.Metadata().Status, "Resource should have been processed")
+	}
 }

--- a/dag_test.go
+++ b/dag_test.go
@@ -1,7 +1,6 @@
 package hclconfig
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -77,38 +76,13 @@ func TestDoYaLikeDAGAddsDependencies(t *testing.T) {
 }
 
 func TestProviderResourceDependency(t *testing.T) {
-	// Create temporary test file that shows provider-resource dependency
-	tmpDir := t.TempDir()
-	testFile := filepath.Join(tmpDir, "test.hcl")
-
-	hclContent := `
-variable "test_value" {
-  default = "from_variable"
-}
-
-provider "simple" {
-  source = "test/simple" 
-  version = "1.0.0"
-  
-  config {
-    value = variable.test_value
-    count = 42
-  }
-}
-
-resource "simple" "test" {
-  provider = "simple"
-  data = "hello world"
-}
-`
-
-	err := os.WriteFile(testFile, []byte(hclContent), 0644)
-	require.NoError(t, err)
+	// Use test fixture for provider-resource dependency
+	testFile := "./internal/test_fixtures/config/providers/basic_provider_with_resources.hcl"
 
 	// Create parser and register plugin
 	parser, _ := setupParser(t)
 	plugin := &SimplePlugin{}
-	err = parser.RegisterPlugin(plugin)
+	err := parser.RegisterPlugin(plugin)
 	require.NoError(t, err)
 
 	// Register plugin source mapping
@@ -144,43 +118,13 @@ resource "simple" "test" {
 }
 
 func TestProviderResourceDependencyInDAG(t *testing.T) {
-	// Create temporary test file
-	tmpDir := t.TempDir() 
-	testFile := filepath.Join(tmpDir, "test.hcl")
-
-	hclContent := `
-variable "endpoint" {
-  default = "https://api.example.com"
-}
-
-provider "simple" {
-  source = "test/simple"
-  version = "1.0.0"
-  
-  config {
-    value = variable.endpoint
-    count = 100
-  }
-}
-
-resource "simple" "app1" {
-  provider = "simple"
-  data = "application 1"
-}
-
-resource "simple" "app2" {
-  provider = "simple" 
-  data = "application 2"
-}
-`
-
-	err := os.WriteFile(testFile, []byte(hclContent), 0644)
-	require.NoError(t, err)
+	// Use test fixture for DAG provider-resource dependencies
+	testFile := "./internal/test_fixtures/config/providers/provider_with_resources.hcl"
 
 	// Create parser and register plugin
 	parser, _ := setupParser(t)
 	plugin := &SimplePlugin{}
-	err = parser.RegisterPlugin(plugin)
+	err := parser.RegisterPlugin(plugin)
 	require.NoError(t, err)
 
 	// Register plugin source mapping  

--- a/example/containerd_provider.go
+++ b/example/containerd_provider.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/jumppad-labs/hclconfig/logger"
+	"github.com/jumppad-labs/hclconfig/plugins"
+	"github.com/jumppad-labs/hclconfig/types"
+)
+
+// ContainerdConfig represents configuration for the Containerd provider
+type ContainerdConfig struct {
+	// Socket is the path to the containerd socket
+	Socket string `hcl:"socket,optional" json:"socket,omitempty"`
+	
+	// Namespace is the containerd namespace to use
+	Namespace string `hcl:"namespace,optional" json:"namespace,omitempty"`
+	
+	// Snapshotter is the snapshotter to use (overlayfs, native, etc.)
+	Snapshotter string `hcl:"snapshotter,optional" json:"snapshotter,omitempty"`
+	
+	// Runtime is the container runtime to use (runc, kata, etc.)
+	Runtime string `hcl:"runtime,optional" json:"runtime,omitempty"`
+}
+
+// ContainerResource represents a container resource
+type ContainerResource struct {
+	types.ResourceBase `hcl:",remain"`
+	
+	// Image is the container image to run
+	Image string `hcl:"image" json:"image"`
+	
+	// Name is the container name
+	Name string `hcl:"name,optional" json:"name,omitempty"`
+	
+	// Command is the command to run in the container
+	Command []string `hcl:"command,optional" json:"command,omitempty"`
+}
+
+// ContainerdPlugin provides containerd-based container resources
+type ContainerdPlugin struct {
+	plugins.PluginBase
+}
+
+// GetConfigType returns the configuration type for this plugin
+func (p *ContainerdPlugin) GetConfigType() reflect.Type {
+	return reflect.TypeOf(ContainerdConfig{})
+}
+
+// Init initializes the containerd plugin
+func (p *ContainerdPlugin) Init(logger logger.Logger, state plugins.State) error {
+	// Create container resource and provider
+	containerResource := &ContainerResource{}
+	containerProvider := &ContainerdResourceProvider[*ContainerResource]{}
+	
+	return plugins.RegisterResourceProvider(
+		&p.PluginBase,
+		logger,
+		state,
+		"resource",
+		"container",
+		containerResource,
+		containerProvider,
+		ContainerdConfig{}, // Default config
+	)
+}
+
+// ContainerdResourceProvider is a provider for containerd-based resources
+type ContainerdResourceProvider[T types.Resource] struct {
+	logger    logger.Logger
+	state     plugins.State
+	functions plugins.ProviderFunctions
+	config    ContainerdConfig
+}
+
+// Init initializes the containerd provider with config
+func (p *ContainerdResourceProvider[T]) Init(state plugins.State, functions plugins.ProviderFunctions, logger logger.Logger, config ContainerdConfig) error {
+	p.state = state
+	p.functions = functions
+	p.logger = logger
+	p.config = config
+	
+	// Log the configuration
+	p.logger.Info("Initializing containerd provider", 
+		"socket", p.config.Socket,
+		"namespace", p.config.Namespace,
+		"snapshotter", p.config.Snapshotter,
+		"runtime", p.config.Runtime)
+	
+	return nil
+}
+
+// Create creates a new container using containerd
+func (p *ContainerdResourceProvider[T]) Create(ctx context.Context, resource T) (T, error) {
+	p.logger.Info("Creating container with containerd", "type", resource.Metadata().Type, "id", resource.Metadata().ID)
+	
+	// In a real implementation, this would:
+	// 1. Connect to containerd using the configured socket
+	// 2. Pull the container image
+	// 3. Create and start the container in the configured namespace
+	// 4. Return the updated resource with status
+	
+	return resource, nil
+}
+
+// Destroy removes a container using containerd
+func (p *ContainerdResourceProvider[T]) Destroy(ctx context.Context, resource T, force bool) error {
+	p.logger.Info("Destroying container with containerd", 
+		"type", resource.Metadata().Type, 
+		"id", resource.Metadata().ID, 
+		"force", force)
+	
+	// In a real implementation, this would:
+	// 1. Connect to containerd
+	// 2. Stop the container
+	// 3. Remove the container
+	// 4. Clean up any associated resources
+	
+	return nil
+}
+
+// Refresh updates the state of a container
+func (p *ContainerdResourceProvider[T]) Refresh(ctx context.Context, resource T) error {
+	p.logger.Info("Refreshing container state", "type", resource.Metadata().Type, "id", resource.Metadata().ID)
+	
+	// In a real implementation, this would:
+	// 1. Connect to containerd
+	// 2. Get the current container status
+	// 3. Update the resource state accordingly
+	
+	return nil
+}
+
+// Update updates a container configuration
+func (p *ContainerdResourceProvider[T]) Update(ctx context.Context, resource T) error {
+	p.logger.Info("Updating container", "type", resource.Metadata().Type, "id", resource.Metadata().ID)
+	
+	// In a real implementation, this would:
+	// 1. Compare old vs new configuration
+	// 2. Recreate the container if necessary
+	// 3. Update any changeable settings
+	
+	return nil
+}
+
+// Changed determines if a container has changed
+func (p *ContainerdResourceProvider[T]) Changed(ctx context.Context, old T, new T) (bool, error) {
+	p.logger.Info("Checking if container changed", "type", old.Metadata().Type, "id", old.Metadata().ID)
+	
+	// In a real implementation, this would compare:
+	// 1. Image versions
+	// 2. Container configuration
+	// 3. Runtime settings
+	// 4. Return true if any significant changes are detected
+	
+	return true, nil // Always return true for demo purposes
+}
+
+// Functions returns provider functions
+func (p *ContainerdResourceProvider[T]) Functions() plugins.ProviderFunctions {
+	return p.functions
+}

--- a/example/main.go
+++ b/example/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"reflect"
 
 	"github.com/jumppad-labs/hclconfig"
 	"github.com/jumppad-labs/hclconfig/logger"
@@ -184,9 +185,19 @@ func demonstrateState(c *hclconfig.Config) {
 	//}, true)
 }
 
+// ExamplePluginConfig represents the configuration for the example plugin
+type ExamplePluginConfig struct {
+	// Empty config for example
+}
+
 // ExamplePlugin provides the Config and PostgreSQL resource types for the example
 type ExamplePlugin struct {
 	plugins.PluginBase
+}
+
+// GetConfigType returns the configuration type for this plugin
+func (p *ExamplePlugin) GetConfigType() reflect.Type {
+	return reflect.TypeOf(ExamplePluginConfig{})
 }
 
 // Init initializes the example plugin
@@ -202,6 +213,7 @@ func (p *ExamplePlugin) Init(logger logger.Logger, state plugins.State) error {
 		"config",
 		configResource,
 		configProvider,
+		ExamplePluginConfig{},
 	)
 	if err != nil {
 		return err
@@ -218,6 +230,7 @@ func (p *ExamplePlugin) Init(logger logger.Logger, state plugins.State) error {
 		"postgres",
 		postgresResource,
 		postgresProvider,
+		ExamplePluginConfig{},
 	)
 }
 
@@ -229,7 +242,7 @@ type ExampleResourceProvider[T types.Resource] struct {
 }
 
 // Init initializes the provider
-func (p *ExampleResourceProvider[T]) Init(state plugins.State, functions plugins.ProviderFunctions, logger logger.Logger) error {
+func (p *ExampleResourceProvider[T]) Init(state plugins.State, functions plugins.ProviderFunctions, logger logger.Logger, config ExamplePluginConfig) error {
 	p.state = state
 	p.functions = functions
 	p.logger = logger

--- a/example/provider_example.hcl
+++ b/example/provider_example.hcl
@@ -1,0 +1,22 @@
+variable "containerd_socket" {
+  default = "/run/containerd/containerd.sock"
+}
+
+provider "container" {
+  source = "jumppad/containerd"
+  version = "~> 1.0"
+  
+  config {
+    socket = variable.containerd_socket
+    namespace = "default"
+    snapshotter = "overlayfs"
+    runtime = "runc"
+  }
+}
+
+resource "container" "web" {
+  provider = "container"
+  image = "nginx:latest"
+  name = "web-server"
+  command = ["nginx", "-g", "daemon off;"]
+}

--- a/example/provider_test.go
+++ b/example/provider_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/jumppad-labs/hclconfig"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProviderBlockParsing(t *testing.T) {
+	// Create a new parser
+	parser := hclconfig.NewParser(nil)
+	
+	// Create and register the containerd plugin
+	containerdPlugin := &ContainerdPlugin{}
+	err := parser.RegisterPlugin(containerdPlugin)
+	require.NoError(t, err, "Should be able to register containerd plugin")
+	
+	// Register the plugin source mapping
+	parser.GetPluginRegistry().RegisterPluginSource("jumppad/containerd", containerdPlugin)
+	
+	// Parse the example configuration
+	config, err := parser.ParseFile("./provider_example.hcl")
+	require.NoError(t, err, "Should be able to parse provider configuration")
+	require.NotNil(t, config, "Config should not be nil")
+	
+	// Verify providers were parsed
+	providers := parser.GetPluginRegistry().ListProviders()
+	require.Contains(t, providers, "container", "Should have registered the container provider")
+	
+	// Verify provider configuration
+	provider, err := parser.GetPluginRegistry().GetProvider("container")
+	require.NoError(t, err, "Should be able to get container provider")
+	require.Equal(t, "jumppad/containerd", provider.Source, "Provider source should match")
+	require.Equal(t, "~> 1.0", provider.Version, "Provider version should match")
+	
+	// Verify config was parsed correctly
+	config_val, ok := provider.Config.(*ContainerdConfig)
+	require.True(t, ok, "Config should be of type ContainerdConfig")
+	
+	t.Logf("Config values: Socket=%s, Namespace=%s, Snapshotter=%s, Runtime=%s", 
+		config_val.Socket, config_val.Namespace, config_val.Snapshotter, config_val.Runtime)
+	
+	require.Equal(t, "/run/containerd/containerd.sock", config_val.Socket, "Socket should be set from variable")
+	require.Equal(t, "default", config_val.Namespace, "Namespace should be set")
+	require.Equal(t, "overlayfs", config_val.Snapshotter, "Snapshotter should be set")
+	require.Equal(t, "runc", config_val.Runtime, "Runtime should be set")
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,9 @@ go 1.23.0
 toolchain go1.24.4
 
 require (
+	github.com/charmbracelet/log v0.4.2
 	github.com/creasty/defaults v1.8.0
+	github.com/fatih/color v1.7.0
 	github.com/flytam/filenamify v1.2.0
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-getter v1.7.5
@@ -36,12 +38,10 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/lipgloss v1.1.0 // indirect
-	github.com/charmbracelet/log v0.4.2 // indirect
 	github.com/charmbracelet/x/ansi v0.8.0 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fatih/color v1.7.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -426,8 +426,6 @@ github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVc
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
-github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
-github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -717,7 +715,6 @@ golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220624220833-87e55d714810/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=

--- a/internal/resources/default.go
+++ b/internal/resources/default.go
@@ -10,5 +10,6 @@ func DefaultResources() types.RegisteredTypes {
 		"local":    &Local{},
 		"module":   &Module{},
 		"root":     &Root{},
+		"provider": &Provider{},
 	}
 }

--- a/internal/resources/provider.go
+++ b/internal/resources/provider.go
@@ -1,0 +1,30 @@
+package resources
+
+import (
+	"reflect"
+
+	"github.com/jumppad-labs/hclconfig/plugins"
+	"github.com/jumppad-labs/hclconfig/types"
+)
+
+const TypeProvider = "provider"
+
+// Provider represents a provider configuration resource, similar to Variable
+// It extends ResourceBase to enable FQRN referencing like provider.name.config.property
+type Provider struct {
+	types.ResourceBase `hcl:",remain"`
+	
+	// Source is the provider source (e.g., "jumppad/containerd")
+	Source string `hcl:"source"`
+	
+	// Version is the provider version constraint (e.g., "~> 1.0")
+	Version string `hcl:"version,optional"`
+	
+	// Config will be populated manually during parsing (config block is dynamic, not via HCL tags)
+	Config interface{} `json:"config,omitempty"`
+	
+	// Internal fields for plugin management (not exposed via HCL)
+	Plugin       plugins.Plugin `json:"-"`
+	ConfigType   reflect.Type   `json:"-"`
+	Initialized  bool           `json:"-"`
+}

--- a/internal/resources/provider.go
+++ b/internal/resources/provider.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"reflect"
 
-	"github.com/jumppad-labs/hclconfig/plugins"
 	"github.com/jumppad-labs/hclconfig/types"
 )
 
@@ -24,7 +23,6 @@ type Provider struct {
 	Config interface{} `json:"config,omitempty"`
 	
 	// Internal fields for plugin management (not exposed via HCL)
-	Plugin       plugins.Plugin `json:"-"`
 	ConfigType   reflect.Type   `json:"-"`
 	Initialized  bool           `json:"-"`
 }

--- a/internal/test_fixtures/config/providers/basic_provider.hcl
+++ b/internal/test_fixtures/config/providers/basic_provider.hcl
@@ -1,0 +1,17 @@
+variable "test_value" {
+  default = "test"
+}
+
+provider "simple" {
+  source = "test/simple"
+  version = "1.0.0"
+  
+  config {
+    value = variable.test_value
+    count = 42
+  }
+}
+
+resource "simple" "test" {
+  data = "hello world"
+}

--- a/internal/test_fixtures/config/providers/basic_provider_with_resources.hcl
+++ b/internal/test_fixtures/config/providers/basic_provider_with_resources.hcl
@@ -1,0 +1,18 @@
+variable "test_value" {
+  default = "from_variable"
+}
+
+provider "simple" {
+  source = "test/simple" 
+  version = "1.0.0"
+  
+  config {
+    value = variable.test_value
+    count = 42
+  }
+}
+
+resource "simple" "test" {
+  provider = "simple"
+  data = "hello world"
+}

--- a/internal/test_fixtures/config/providers/circular_variables.hcl
+++ b/internal/test_fixtures/config/providers/circular_variables.hcl
@@ -1,0 +1,16 @@
+variable "var1" {
+  default = variable.var2
+}
+
+variable "var2" {
+  default = variable.var1
+}
+
+provider "error_test" {
+  source = "test/error"
+  version = "1.0.0"
+  
+  config {
+    required_field = variable.var1
+  }
+}

--- a/internal/test_fixtures/config/providers/multiple_providers.hcl
+++ b/internal/test_fixtures/config/providers/multiple_providers.hcl
@@ -1,0 +1,19 @@
+provider "simple1" {
+  source = "test/simple"
+  version = "1.0.0"
+  
+  config {
+    value = "provider1"
+    count = 1
+  }
+}
+
+provider "simple2" {
+  source = "test/simple"
+  version = "1.0.0"
+  
+  config {
+    value = "provider2"
+    count = 2
+  }
+}

--- a/internal/test_fixtures/config/providers/provider_with_resources.hcl
+++ b/internal/test_fixtures/config/providers/provider_with_resources.hcl
@@ -1,0 +1,23 @@
+variable "endpoint" {
+  default = "https://api.example.com"
+}
+
+provider "simple" {
+  source = "test/simple"
+  version = "1.0.0"
+  
+  config {
+    value = variable.endpoint
+    count = 100
+  }
+}
+
+resource "simple" "app1" {
+  provider = "simple"
+  data = "application 1"
+}
+
+resource "simple" "app2" {
+  provider = "simple" 
+  data = "application 2"
+}

--- a/internal/test_fixtures/plugin/test_plugin.go
+++ b/internal/test_fixtures/plugin/test_plugin.go
@@ -9,10 +9,17 @@ import (
 	"github.com/jumppad-labs/hclconfig/types"
 )
 
+// TestPluginConfig represents the configuration for the test plugin
+type TestPluginConfig struct {
+	// Empty config for testing
+}
+
 // TestPlugin provides test resource types for testing the parser
 type TestPlugin struct {
 	plugins.PluginBase
 }
+
+// GetConfigType is now automatically provided by PluginBase
 
 // Ensure TestPlugin implements Plugin interface
 var _ plugins.Plugin = (*TestPlugin)(nil)
@@ -22,6 +29,7 @@ func (p *TestPlugin) Init(logger logger.Logger, state plugins.State) error {
 	// Register Container resource
 	containerResource := &structs.Container{}
 	containerProvider := &TestResourceProvider[*structs.Container]{}
+	var config TestPluginConfig
 	err := plugins.RegisterResourceProvider(
 		&p.PluginBase,
 		logger,
@@ -30,6 +38,7 @@ func (p *TestPlugin) Init(logger logger.Logger, state plugins.State) error {
 		"container",
 		containerResource,
 		containerProvider,
+		config,
 	)
 	if err != nil {
 		return err
@@ -45,6 +54,7 @@ func (p *TestPlugin) Init(logger logger.Logger, state plugins.State) error {
 		"sidecar",
 		sidecarResource,
 		sidecarProvider,
+		config,
 	)
 	if err != nil {
 		return err
@@ -61,6 +71,7 @@ func (p *TestPlugin) Init(logger logger.Logger, state plugins.State) error {
 		"network",
 		networkResource,
 		networkProvider,
+		config,
 	)
 	if err != nil {
 		return err
@@ -77,6 +88,7 @@ func (p *TestPlugin) Init(logger logger.Logger, state plugins.State) error {
 		"template",
 		templateResource,
 		templateProvider,
+		config,
 	)
 	if err != nil {
 		return err
@@ -93,7 +105,7 @@ type TestResourceProvider[T types.Resource] struct {
 }
 
 // Init initializes the test provider
-func (p *TestResourceProvider[T]) Init(state plugins.State, functions plugins.ProviderFunctions, logger logger.Logger) error {
+func (p *TestResourceProvider[T]) Init(state plugins.State, functions plugins.ProviderFunctions, logger logger.Logger, config TestPluginConfig) error {
 	p.state = state
 	p.functions = functions
 	p.logger = logger

--- a/output.txt
+++ b/output.txt
@@ -1,1 +1,0 @@
-stat main.go: no such file or directory

--- a/parser_plugin_test.go
+++ b/parser_plugin_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/jumppad-labs/hclconfig/logger"
-	"github.com/jumppad-labs/hclconfig/plugins/example/pkg/person"
 	"github.com/jumppad-labs/hclconfig/plugins"
+	"github.com/jumppad-labs/hclconfig/plugins/example/pkg/person"
 	"github.com/stretchr/testify/require"
 )
 
@@ -53,6 +53,7 @@ func (p *SimpleTestPlugin) Init(logger logger.Logger, state plugins.State) error
 	// Create test person resource and provider
 	personResource := &person.Person{}
 	personProvider := &person.ExampleProvider{}
+	personConfig := person.ExampleProviderConfig{}
 
 	// Register the Person resource type with the plugin
 	return plugins.RegisterResourceProvider(
@@ -63,5 +64,6 @@ func (p *SimpleTestPlugin) Init(logger logger.Logger, state plugins.State) error
 		"person",       // Sub-type
 		personResource, // Resource instance
 		personProvider, // Provider instance
+		personConfig,   // Provider config instance
 	)
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -1280,7 +1280,7 @@ resource "simple" "test" {
 	require.NoError(t, err)
 
 	// Create parser and register plugin
-	parser := NewParser(nil)
+	parser, _ := setupParser(t)
 	plugin := &SimplePlugin{}
 	err = parser.RegisterPlugin(plugin)
 	require.NoError(t, err)
@@ -1343,7 +1343,7 @@ provider "unknown" {
 	require.NoError(t, err)
 
 	// Create parser without registering the required plugin
-	parser := NewParser(nil)
+	parser, _ := setupParser(t)
 
 	// Parse should fail due to missing plugin
 	_, err = parser.ParseFile(testFile)
@@ -1371,7 +1371,7 @@ provider "simple" {
 	require.NoError(t, err)
 
 	// Create parser and register plugin
-	parser := NewParser(nil)
+	parser, _ := setupParser(t)
 	plugin := &SimplePlugin{}
 	err = parser.RegisterPlugin(plugin)
 	require.NoError(t, err)
@@ -1416,7 +1416,7 @@ provider "simple2" {
 	require.NoError(t, err)
 
 	// Create parser and register plugin
-	parser := NewParser(nil)
+	parser, _ := setupParser(t)
 	plugin := &SimplePlugin{}
 	err = parser.RegisterPlugin(plugin)
 	require.NoError(t, err)
@@ -1479,7 +1479,7 @@ provider "simple" {
 	require.NoError(t, err)
 
 	// Create parser and register plugin
-	parser := NewParser(nil)
+	parser, _ := setupParser(t)
 	plugin := &SimplePlugin{}
 	err = parser.RegisterPlugin(plugin)
 	require.NoError(t, err)
@@ -1532,7 +1532,7 @@ variable "config_value" {
 	require.NoError(t, err)
 
 	// Create parser with our simple plugin
-	parser := NewParser(nil)
+	parser, _ := setupParser(t)
 	plugin := &SimplePlugin{}
 	err = parser.RegisterPlugin(plugin)
 	require.NoError(t, err)
@@ -1589,7 +1589,7 @@ resource "simple" "test" {
 	require.NoError(t, err)
 
 	// Create parser with our simple plugin
-	parser := NewParser(nil)
+	parser, _ := setupParser(t)
 	plugin := &SimplePlugin{}
 	err = parser.RegisterPlugin(plugin)
 	require.NoError(t, err)
@@ -1654,13 +1654,13 @@ variable "late_defined_var" {
 	err := os.WriteFile(testFile, []byte(hclContent), 0644)
 	require.NoError(t, err)
 
-	// Create parser with variable override
+	// Create parser with variable override using setupParser
 	options := DefaultOptions()
 	options.Variables = map[string]string{
 		"late_defined_var": "overridden_value",
 	}
 	
-	parser := NewParser(options)
+	parser, _ := setupParser(t, options)
 	plugin := &SimplePlugin{}
 	err = parser.RegisterPlugin(plugin)
 	require.NoError(t, err)

--- a/parser_test.go
+++ b/parser_test.go
@@ -1251,37 +1251,13 @@ func (p *SimplePlugin) Init(logger plugins.Logger, state plugins.State) error {
 }
 
 func TestParseProviderBlocks(t *testing.T) {
-	// Create temporary test file
-	tmpDir := t.TempDir()
-	testFile := filepath.Join(tmpDir, "test.hcl")
-
-	hclContent := `
-variable "test_value" {
-  default = "test"
-}
-
-provider "simple" {
-  source = "test/simple"
-  version = "1.0.0"
-  
-  config {
-    value = variable.test_value
-    count = 42
-  }
-}
-
-resource "simple" "test" {
-  data = "hello world"
-}
-`
-
-	err := os.WriteFile(testFile, []byte(hclContent), 0644)
-	require.NoError(t, err)
+	// Use test fixture for provider blocks
+	testFile := "./internal/test_fixtures/config/providers/basic_provider.hcl"
 
 	// Create parser and register plugin
 	parser, _ := setupParser(t)
 	plugin := &SimplePlugin{}
-	err = parser.RegisterPlugin(plugin)
+	err := parser.RegisterPlugin(plugin)
 	require.NoError(t, err)
 
 	// Register plugin source mapping
@@ -1385,39 +1361,13 @@ provider "simple" {
 }
 
 func TestParseMultipleProviders(t *testing.T) {
-	// Create temporary test file
-	tmpDir := t.TempDir()
-	testFile := filepath.Join(tmpDir, "test.hcl")
-
-	hclContent := `
-provider "simple1" {
-  source = "test/simple"
-  version = "1.0.0"
-  
-  config {
-    value = "provider1"
-    count = 1
-  }
-}
-
-provider "simple2" {
-  source = "test/simple"
-  version = "1.0.0"
-  
-  config {
-    value = "provider2"
-    count = 2
-  }
-}
-`
-
-	err := os.WriteFile(testFile, []byte(hclContent), 0644)
-	require.NoError(t, err)
+	// Use test fixture for multiple providers
+	testFile := "./internal/test_fixtures/config/providers/multiple_providers.hcl"
 
 	// Create parser and register plugin
 	parser, _ := setupParser(t)
 	plugin := &SimplePlugin{}
-	err = parser.RegisterPlugin(plugin)
+	err := parser.RegisterPlugin(plugin)
 	require.NoError(t, err)
 
 	// Register plugin source mapping

--- a/plugin_registry.go
+++ b/plugin_registry.go
@@ -314,7 +314,6 @@ func (r *PluginRegistry) RegisterProvider(provider *resources.Provider, ctx *hcl
 	}
 
 	// Set up plugin-specific fields
-	provider.Plugin = plugin
 	provider.ConfigType = configType
 	provider.Initialized = false
 
@@ -371,16 +370,9 @@ func (r *PluginRegistry) RegisterPluginSource(source string, plugin plugins.Plug
 
 // findPluginBySource finds a plugin by its source identifier
 func (r *PluginRegistry) findPluginBySource(source string) (plugins.Plugin, error) {
-	// Look in the dedicated plugins map first
+	// Look in the dedicated plugins map
 	if plugin, exists := r.plugins[source]; exists {
 		return plugin, nil
-	}
-	
-	// Also look through existing providers to find matching source (for backwards compatibility)
-	for _, provider := range r.providers {
-		if provider.Source == source {
-			return provider.Plugin, nil
-		}
 	}
 	
 	return nil, fmt.Errorf("plugin with source '%s' not found - use RegisterPluginSource to register it", source)

--- a/plugin_registry.go
+++ b/plugin_registry.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/jumppad-labs/hclconfig/internal/resources"
 	"github.com/jumppad-labs/hclconfig/logger"
 	"github.com/jumppad-labs/hclconfig/plugins"
@@ -12,11 +14,22 @@ import (
 	"github.com/jumppad-labs/hclconfig/types"
 )
 
-// PluginRegistry manages all resource types (builtin and plugin-based) and can create resource instances
+
+// PluginRegistry manages all resource types (builtin and plugin-based), can create resource instances,
+// and manages provider configurations
 type PluginRegistry struct {
 	builtinTypes types.RegisteredTypes
 	pluginHosts  []plugins.PluginHost
 	logger       logger.Logger
+	
+	// Plugin and provider management
+	// plugins: maps source identifiers (e.g., "jumppad/containerd") to plugin implementations
+	// This allows finding which plugin handles a given source when registering providers
+	plugins      map[string]plugins.Plugin  // source -> plugin mapping
+	
+	// providers: maps provider instance names (e.g., "docker", "podman") to configured provider instances
+	// Each provider instance has a name, references a source plugin, and contains typed configuration
+	providers    map[string]*resources.Provider // name -> configured provider instance
 }
 
 // NewPluginRegistry creates a new plugin registry with builtin types
@@ -25,6 +38,8 @@ func NewPluginRegistry(logger logger.Logger) *PluginRegistry {
 		builtinTypes: resources.DefaultResources(),
 		pluginHosts:  []plugins.PluginHost{},
 		logger:       logger,
+		plugins:      make(map[string]plugins.Plugin),
+		providers:    make(map[string]*resources.Provider),
 	}
 }
 
@@ -72,9 +87,9 @@ func (r *PluginRegistry) createResourceFromPlugins(resourceType, resourceName st
 	return nil, fmt.Errorf("resource type %s not found in any registered plugin", resourceType)
 }
 
-// GetProvider finds the provider adapter for a given resource
+// GetProviderAdapter finds the provider adapter for a given resource
 // Returns nil if the resource type is a builtin type (not handled by plugins)
-func (r *PluginRegistry) GetProvider(resource types.Resource) plugins.ProviderAdapter {
+func (r *PluginRegistry) GetProviderAdapter(resource types.Resource) plugins.ProviderAdapter {
 	resourceType := resource.Metadata().Type
 	
 	// Check if it's a builtin type
@@ -98,6 +113,7 @@ func (r *PluginRegistry) GetProvider(resource types.Resource) plugins.ProviderAd
 	// No plugin found for this resource type
 	return nil
 }
+
 
 // RegisterPlugin registers an in-process plugin with the registry
 func (r *PluginRegistry) RegisterPlugin(plugin plugins.Plugin) error {
@@ -248,4 +264,159 @@ func CastResourceTo[T types.Resource](registry *PluginRegistry, resource types.R
 	}
 	
 	return zero, fmt.Errorf("resource cannot be cast to requested type")
+}
+
+// Provider Configuration Methods
+
+// RegisterProvider registers a provider instance with its configuration
+// This is called after the provider resource has been parsed to set up plugin-specific fields
+func (r *PluginRegistry) RegisterProvider(provider *resources.Provider, ctx *hcl.EvalContext) error {
+	// Validate required fields
+	if provider.Metadata().Name == "" {
+		return fmt.Errorf("provider name cannot be empty")
+	}
+	if provider.Source == "" {
+		return fmt.Errorf("provider source cannot be empty")
+	}
+
+	// Check if provider name already exists
+	if _, exists := r.providers[provider.Metadata().Name]; exists {
+		return fmt.Errorf("provider '%s' is already defined", provider.Metadata().Name)
+	}
+
+	// Find plugin by source
+	plugin, err := r.findPluginBySource(provider.Source)
+	if err != nil {
+		return fmt.Errorf("failed to find plugin for source '%s': %w", provider.Source, err)
+	}
+
+	// Get config type from plugin
+	configType := plugin.GetConfigType()
+	if configType == nil {
+		return fmt.Errorf("plugin for source '%s' does not define a configuration type", provider.Source)
+	}
+
+	// Convert hcl.Body config to concrete type if config is provided
+	if provider.Config != nil {
+		if configBody, ok := provider.Config.(hcl.Body); ok {
+			// Create an instance of the concrete config type
+			configPtr := reflect.New(configType).Interface()
+			
+			// Decode the config body to the concrete type
+			diags := gohcl.DecodeBody(configBody, ctx, configPtr)
+			if diags.HasErrors() {
+				return fmt.Errorf("failed to decode provider config: %s", diags.Error())
+			}
+			
+			// Store the concrete config as a pointer
+			provider.Config = configPtr
+		}
+	}
+
+	// Set up plugin-specific fields
+	provider.Plugin = plugin
+	provider.ConfigType = configType
+	provider.Initialized = false
+
+	// Register this provider instance for quick lookup
+	r.providers[provider.Metadata().Name] = provider
+	return nil
+}
+
+
+// GetProvider returns a provider instance by name
+func (r *PluginRegistry) GetProvider(name string) (*resources.Provider, error) {
+	providerConfig, exists := r.providers[name]
+	if !exists {
+		return nil, fmt.Errorf("provider '%s' is not defined", name)
+	}
+	return providerConfig, nil
+}
+
+// GetDefaultProvider returns the default provider for a resource type
+// Default provider name matches resource type (e.g., "container" provider for container resources)
+func (r *PluginRegistry) GetDefaultProvider(resourceType string) (*resources.Provider, error) {
+	return r.GetProvider(resourceType)
+}
+
+// ListProviders returns all registered provider names (excluding internal source mappings)
+func (r *PluginRegistry) ListProviders() []string {
+	names := make([]string, 0, len(r.providers))
+	for name := range r.providers {
+		// Skip internal source mapping entries
+		if !strings.HasPrefix(name, "_source_") {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// ResolveProviderForResource determines which provider should handle a resource
+func (r *PluginRegistry) ResolveProviderForResource(resource interface{}) (*resources.Provider, error) {
+	// Check if resource has explicit provider field
+	if providerField, err := getProviderField(resource); err == nil && providerField != "" {
+		return r.GetProvider(providerField)
+	}
+
+	// Fall back to default provider based on resource type
+	resourceType := getResourceType(resource)
+	return r.GetDefaultProvider(resourceType)
+}
+
+// RegisterPluginSource registers a plugin with a source identifier for provider configuration
+func (r *PluginRegistry) RegisterPluginSource(source string, plugin plugins.Plugin) {
+	// Store the plugin directly in the plugins map
+	r.plugins[source] = plugin
+}
+
+// findPluginBySource finds a plugin by its source identifier
+func (r *PluginRegistry) findPluginBySource(source string) (plugins.Plugin, error) {
+	// Look in the dedicated plugins map first
+	if plugin, exists := r.plugins[source]; exists {
+		return plugin, nil
+	}
+	
+	// Also look through existing providers to find matching source (for backwards compatibility)
+	for _, provider := range r.providers {
+		if provider.Source == source {
+			return provider.Plugin, nil
+		}
+	}
+	
+	return nil, fmt.Errorf("plugin with source '%s' not found - use RegisterPluginSource to register it", source)
+}
+
+// Helper function to extract provider field from resource using reflection
+func getProviderField(resource interface{}) (string, error) {
+	val := reflect.ValueOf(resource)
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+
+	if val.Kind() != reflect.Struct {
+		return "", fmt.Errorf("resource is not a struct")
+	}
+
+	// Look for Provider field
+	providerField := val.FieldByName("Provider")
+	if !providerField.IsValid() {
+		return "", fmt.Errorf("resource does not have Provider field")
+	}
+
+	if providerField.Kind() != reflect.String {
+		return "", fmt.Errorf("Provider field is not a string")
+	}
+
+	return providerField.String(), nil
+}
+
+// Helper function to extract resource type
+func getResourceType(resource interface{}) string {
+	// This is a simplified implementation
+	// In practice, you'd extract this from the resource's metadata
+	val := reflect.TypeOf(resource)
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+	return val.Name()
 }

--- a/plugin_registry_test.go
+++ b/plugin_registry_test.go
@@ -1,0 +1,828 @@
+package hclconfig
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/jumppad-labs/hclconfig/internal/resources"
+	"github.com/jumppad-labs/hclconfig/logger"
+	"github.com/jumppad-labs/hclconfig/plugins"
+	"github.com/jumppad-labs/hclconfig/types"
+	"github.com/stretchr/testify/require"
+)
+
+// Test types for provider registry testing
+type TestConfig struct {
+	Field1 string `hcl:"field1,optional"`
+	Field2 int    `hcl:"field2,optional"`
+}
+
+type TestResource struct {
+	types.ResourceBase `hcl:",remain"`
+	Value              string `hcl:"value"`
+}
+
+type TestProvider struct {
+	initialized bool
+	config      TestConfig
+}
+
+func (p *TestProvider) Init(state plugins.State, functions plugins.ProviderFunctions, logger plugins.Logger, config TestConfig) error {
+	p.initialized = true
+	p.config = config
+	return nil
+}
+
+func (p *TestProvider) Create(ctx context.Context, resource *TestResource) (*TestResource, error) {
+	return resource, nil
+}
+
+func (p *TestProvider) Destroy(ctx context.Context, resource *TestResource, force bool) error {
+	return nil
+}
+
+func (p *TestProvider) Refresh(ctx context.Context, resource *TestResource) error {
+	return nil
+}
+
+func (p *TestProvider) Changed(ctx context.Context, current *TestResource, desired *TestResource) (bool, error) {
+	return false, nil
+}
+
+func (p *TestProvider) Update(ctx context.Context, resource *TestResource) error {
+	return nil
+}
+
+func (p *TestProvider) Functions() plugins.ProviderFunctions {
+	return nil
+}
+
+type RegistryTestPlugin struct {
+	plugins.PluginBase
+}
+
+
+func (p *RegistryTestPlugin) Init(logger plugins.Logger, state plugins.State) error {
+	// Register a test resource type to set up config type in PluginBase
+	testResource := &TestResource{}
+	testProvider := &TestProvider{}
+	config := TestConfig{}
+	
+	return plugins.RegisterResourceProvider(
+		&p.PluginBase,
+		logger,
+		state,
+		"resource",
+		"test",
+		testResource,
+		testProvider,
+		config,
+	)
+}
+
+func TestPluginRegistryRegisterProvider(t *testing.T) {
+	registry := NewPluginRegistry(logger.NewTestLogger(t))
+
+	// Create a test provider
+	provider := &resources.Provider{
+		Source:  "test/provider",
+		Version: "1.0.0",
+	}
+	provider.Metadata().Name = "test-provider"
+	provider.Metadata().Type = resources.TypeProvider
+
+	// Register a test plugin
+	plugin := &RegistryTestPlugin{}
+	err := registry.RegisterPlugin(plugin)
+	require.NoError(t, err)
+	registry.RegisterPluginSource("test/provider", plugin)
+
+	// Register the provider
+	ctx := &hcl.EvalContext{}
+	err = registry.RegisterProvider(provider, ctx)
+	require.NoError(t, err)
+
+	// Verify provider was registered
+	providers := registry.ListProviders()
+	require.Contains(t, providers, "test-provider")
+
+	// Get the provider
+	providerConfig, err := registry.GetProvider("test-provider")
+	require.NoError(t, err)
+	require.Equal(t, "test-provider", providerConfig.Metadata().Name)
+	require.Equal(t, "test/provider", providerConfig.Source)
+	require.Equal(t, "1.0.0", providerConfig.Version)
+	require.Equal(t, plugin, providerConfig.Plugin)
+}
+
+func TestRegisterProviderDuplicateName(t *testing.T) {
+	registry := NewPluginRegistry(logger.NewTestLogger(t))
+
+	plugin := &RegistryTestPlugin{}
+	err := registry.RegisterPlugin(plugin)
+	require.NoError(t, err)
+	registry.RegisterPluginSource("test/provider", plugin)
+
+	provider1 := &resources.Provider{
+		Source:  "test/provider",
+		Version: "1.0.0",
+	}
+	provider1.Metadata().Name = "test-provider"
+	provider1.Metadata().Type = resources.TypeProvider
+
+	provider2 := &resources.Provider{
+		Source:  "test/other",
+		Version: "2.0.0",
+	}
+	provider2.Metadata().Name = "test-provider"
+	provider2.Metadata().Type = resources.TypeProvider
+
+	ctx := &hcl.EvalContext{}
+
+	// Register first provider
+	err = registry.RegisterProvider(provider1, ctx)
+	require.NoError(t, err)
+
+	// Try to register duplicate name
+	err = registry.RegisterProvider(provider2, ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "already defined")
+}
+
+func TestGetProviderNotFound(t *testing.T) {
+	registry := NewPluginRegistry(logger.NewTestLogger(t))
+
+	_, err := registry.GetProvider("nonexistent")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not defined")
+}
+
+func TestGetDefaultProvider(t *testing.T) {
+	t.Run("success case", func(t *testing.T) {
+		registry := NewPluginRegistry(logger.NewTestLogger(t))
+
+		plugin := &RegistryTestPlugin{}
+		err := registry.RegisterPlugin(plugin)
+		require.NoError(t, err)
+		registry.RegisterPluginSource("test/provider", plugin)
+
+		// Register a provider with name "container"
+		provider := &resources.Provider{
+			Source:  "test/provider",
+			Version: "1.0.0",
+		}
+		provider.Metadata().Name = "container"
+		provider.Metadata().Type = resources.TypeProvider
+
+		ctx := &hcl.EvalContext{}
+		err = registry.RegisterProvider(provider, ctx)
+		require.NoError(t, err)
+
+		// Get default provider for "container" resource type
+		providerConfig, err := registry.GetDefaultProvider("container")
+		require.NoError(t, err)
+		require.Equal(t, "container", providerConfig.Metadata().Name)
+		require.Equal(t, "test/provider", providerConfig.Source)
+		require.Equal(t, "1.0.0", providerConfig.Version)
+	})
+
+	t.Run("provider not found", func(t *testing.T) {
+		registry := NewPluginRegistry(logger.NewTestLogger(t))
+
+		// Try to get default provider for unregistered resource type
+		_, err := registry.GetDefaultProvider("nonexistent")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not defined")
+	})
+
+	t.Run("empty resource type", func(t *testing.T) {
+		registry := NewPluginRegistry(logger.NewTestLogger(t))
+
+		// Try to get default provider for empty resource type
+		_, err := registry.GetDefaultProvider("")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not defined")
+	})
+}
+
+func TestResolveProviderForResource(t *testing.T) {
+	// Test resource with explicit provider field  
+	type TestResourceWithProvider struct {
+		Provider string
+		Data     string
+	}
+
+	// Test resource without explicit provider field
+	type TestResourceWithoutProvider struct {
+		Data string
+	}
+
+	t.Run("resource with explicit provider field", func(t *testing.T) {
+		registry := NewPluginRegistry(logger.NewTestLogger(t))
+
+		plugin := &RegistryTestPlugin{}
+		err := registry.RegisterPlugin(plugin)
+		require.NoError(t, err)
+		registry.RegisterPluginSource("test/provider", plugin)
+
+		// Register a provider with name "custom-provider"
+		provider := &resources.Provider{
+			Source:  "test/provider", 
+			Version: "1.0.0",
+		}
+		provider.Metadata().Name = "custom-provider"
+		provider.Metadata().Type = resources.TypeProvider
+
+		ctx := &hcl.EvalContext{}
+		err = registry.RegisterProvider(provider, ctx)
+		require.NoError(t, err)
+
+		// Create resource with explicit provider
+		resource := &TestResourceWithProvider{
+			Provider: "custom-provider",
+			Data:     "test",
+		}
+
+		// Resolve provider should return the explicit provider
+		providerConfig, err := registry.ResolveProviderForResource(resource)
+		require.NoError(t, err)
+		require.Equal(t, "custom-provider", providerConfig.Metadata().Name)
+	})
+
+	t.Run("resource without provider field falls back to default", func(t *testing.T) {
+		registry := NewPluginRegistry(logger.NewTestLogger(t))
+
+		plugin := &RegistryTestPlugin{}
+		err := registry.RegisterPlugin(plugin)
+		require.NoError(t, err)
+		registry.RegisterPluginSource("test/provider", plugin)
+
+		// Register a provider with name matching resource type
+		provider := &resources.Provider{
+			Source:  "test/provider",
+			Version: "1.0.0",
+		}
+		provider.Metadata().Name = "TestResourceWithoutProvider" // Should match struct name
+		provider.Metadata().Type = resources.TypeProvider
+
+		ctx := &hcl.EvalContext{}
+		err = registry.RegisterProvider(provider, ctx)
+		require.NoError(t, err)
+
+		// Create resource without provider field
+		resource := &TestResourceWithoutProvider{
+			Data: "test",
+		}
+
+		// Resolve provider should fall back to default based on type
+		providerConfig, err := registry.ResolveProviderForResource(resource)
+		require.NoError(t, err)
+		require.Equal(t, "TestResourceWithoutProvider", providerConfig.Metadata().Name)
+	})
+
+	t.Run("explicit provider not found", func(t *testing.T) {
+		registry := NewPluginRegistry(logger.NewTestLogger(t))
+
+		// Create resource with non-existent provider
+		resource := &TestResourceWithProvider{
+			Provider: "nonexistent-provider",
+			Data:     "test",
+		}
+
+		// Should return error for non-existent provider
+		_, err := registry.ResolveProviderForResource(resource)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not defined")
+	})
+
+	t.Run("default provider not found", func(t *testing.T) {
+		registry := NewPluginRegistry(logger.NewTestLogger(t))
+
+		// Create resource without provider field and no matching default
+		resource := &TestResourceWithoutProvider{
+			Data: "test",
+		}
+
+		// Should return error for missing default provider
+		_, err := registry.ResolveProviderForResource(resource)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not defined")
+	})
+}
+
+func TestListProviders(t *testing.T) {
+	registry := NewPluginRegistry(logger.NewTestLogger(t))
+
+	// Initially should be empty
+	providers := registry.ListProviders()
+	require.Empty(t, providers)
+
+	// Register a plugin source
+	plugin := &RegistryTestPlugin{}
+	err := registry.RegisterPlugin(plugin)
+	require.NoError(t, err)
+	registry.RegisterPluginSource("test/provider", plugin)
+	
+	// After registering plugin source, providers list should still be empty
+	providers = registry.ListProviders()
+	require.Empty(t, providers)
+
+	// Register actual providers
+	ctx := &hcl.EvalContext{}
+
+	// Register first provider
+	provider1 := &resources.Provider{
+		Source:  "test/provider",
+		Version: "1.0.0",
+	}
+	provider1.Metadata().Name = "provider1"
+	provider1.Metadata().Type = resources.TypeProvider
+	err = registry.RegisterProvider(provider1, ctx)
+	require.NoError(t, err)
+
+	// Register second provider
+	provider2 := &resources.Provider{
+		Source:  "test/provider",
+		Version: "2.0.0",
+	}
+	provider2.Metadata().Name = "provider2"
+	provider2.Metadata().Type = resources.TypeProvider
+	err = registry.RegisterProvider(provider2, ctx)
+	require.NoError(t, err)
+
+	// List should contain exactly our 2 providers (no internal mappings)
+	providers = registry.ListProviders()
+	require.Len(t, providers, 2)
+	require.Contains(t, providers, "provider1")
+	require.Contains(t, providers, "provider2")
+}
+
+func TestRegisterPluginSource(t *testing.T) {
+	registry := NewPluginRegistry(logger.NewTestLogger(t))
+	plugin := &RegistryTestPlugin{}
+	err := registry.RegisterPlugin(plugin)
+	require.NoError(t, err)
+
+	registry.RegisterPluginSource("test/source", plugin)
+
+	// Verify we can find the plugin by source
+	foundPlugin, err := registry.findPluginBySource("test/source")
+	require.NoError(t, err)
+	require.Equal(t, plugin, foundPlugin)
+}
+
+func TestFindPluginBySourceNotFound(t *testing.T) {
+	registry := NewPluginRegistry(logger.NewTestLogger(t))
+
+	_, err := registry.findPluginBySource("nonexistent/source")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestProviderValidationValidBlock(t *testing.T) {
+	registry := NewPluginRegistry(logger.NewTestLogger(t))
+	plugin := &RegistryTestPlugin{}
+	err := registry.RegisterPlugin(plugin)
+	require.NoError(t, err)
+	ctx := &hcl.EvalContext{}
+
+	provider := &resources.Provider{
+		Source:  "test/provider",
+		Version: "1.0.0",
+	}
+	provider.Metadata().Name = "test"
+	provider.Metadata().Type = resources.TypeProvider
+
+	registry.RegisterPluginSource(provider.Source, plugin)
+	err = registry.RegisterProvider(provider, ctx)
+	require.NoError(t, err)
+}
+
+func TestProviderValidationEmptyName(t *testing.T) {
+	registry := NewPluginRegistry(logger.NewTestLogger(t))
+	ctx := &hcl.EvalContext{}
+
+	provider := &resources.Provider{
+		Source:  "test/provider",
+		Version: "1.0.0",
+	}
+	provider.Metadata().Name = ""
+	provider.Metadata().Type = resources.TypeProvider
+
+	err := registry.RegisterProvider(provider, ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "name cannot be empty")
+}
+
+func TestProviderValidationEmptySource(t *testing.T) {
+	registry := NewPluginRegistry(logger.NewTestLogger(t))
+	ctx := &hcl.EvalContext{}
+
+	provider := &resources.Provider{
+		Source:  "",
+		Version: "1.0.0",
+	}
+	provider.Metadata().Name = "test"
+	provider.Metadata().Type = resources.TypeProvider
+
+	err := registry.RegisterProvider(provider, ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "source cannot be empty")
+}
+
+// Test fixtures for error handling tests
+type ErrorTestConfig struct {
+	RequiredField string `hcl:"required_field"`
+	OptionalField string `hcl:"optional_field,optional"`
+}
+
+type ErrorTestResource struct {
+	types.ResourceBase `hcl:",remain"`
+	Data               string `hcl:"data"`
+}
+
+type ErrorTestProvider struct{}
+
+func (p *ErrorTestProvider) Init(state plugins.State, functions plugins.ProviderFunctions, logger plugins.Logger, config ErrorTestConfig) error {
+	return nil
+}
+
+func (p *ErrorTestProvider) Create(ctx context.Context, resource *ErrorTestResource) (*ErrorTestResource, error) {
+	return resource, nil
+}
+
+func (p *ErrorTestProvider) Destroy(ctx context.Context, resource *ErrorTestResource, force bool) error {
+	return nil
+}
+
+func (p *ErrorTestProvider) Refresh(ctx context.Context, resource *ErrorTestResource) error {
+	return nil
+}
+
+func (p *ErrorTestProvider) Changed(ctx context.Context, current *ErrorTestResource, desired *ErrorTestResource) (bool, error) {
+	return false, nil
+}
+
+func (p *ErrorTestProvider) Update(ctx context.Context, resource *ErrorTestResource) error {
+	return nil
+}
+
+func (p *ErrorTestProvider) Functions() plugins.ProviderFunctions {
+	return nil
+}
+
+type ErrorTestPlugin struct {
+	plugins.PluginBase
+}
+
+
+func (p *ErrorTestPlugin) Init(logger plugins.Logger, state plugins.State) error {
+	resource := &ErrorTestResource{}
+	provider := &ErrorTestProvider{}
+	config := ErrorTestConfig{RequiredField: "default", OptionalField: "optional"}
+
+	return plugins.RegisterResourceProvider(
+		&p.PluginBase,
+		logger,
+		state,
+		"resource",
+		"error_test",
+		resource,
+		provider,
+		config,
+	)
+}
+
+func TestProviderErrorMissingRequiredField(t *testing.T) {
+	// Create temporary test file with missing required field
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.hcl")
+
+	hclContent := `
+provider "error_test" {
+  source = "test/error"
+  version = "1.0.0"
+  
+  config {
+    # missing required_field
+    optional_field = "present"
+  }
+}
+`
+
+	err := os.WriteFile(testFile, []byte(hclContent), 0644)
+	require.NoError(t, err)
+
+	// Create parser and register plugin
+	parser := NewParser(nil)
+	plugin := &ErrorTestPlugin{}
+	err = parser.RegisterPlugin(plugin)
+	require.NoError(t, err)
+
+	parser.GetPluginRegistry().RegisterPluginSource("test/error", plugin)
+
+	// Parse should fail due to missing required field
+	_, err = parser.ParseFile(testFile)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "required_field") // Should mention the missing field
+}
+
+func TestProviderErrorInvalidSource(t *testing.T) {
+	// Create temporary test file with invalid source
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.hcl")
+
+	hclContent := `
+provider "error_test" {
+  source = "invalid/source"  # This source is not registered
+  version = "1.0.0"
+  
+  config {
+    required_field = "test"
+  }
+}
+`
+
+	err := os.WriteFile(testFile, []byte(hclContent), 0644)
+	require.NoError(t, err)
+
+	// Create parser and register plugin with different source
+	parser := NewParser(nil)
+	plugin := &ErrorTestPlugin{}
+	err = parser.RegisterPlugin(plugin)
+	require.NoError(t, err)
+
+	parser.GetPluginRegistry().RegisterPluginSource("test/error", plugin) // Different source
+
+	// Parse should fail due to source not found
+	_, err = parser.ParseFile(testFile)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestProviderErrorMalformedHCL(t *testing.T) {
+	// Create temporary test file with malformed HCL
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.hcl")
+
+	hclContent := `
+provider "error_test" {
+  source = "test/error"
+  version = "1.0.0"
+  
+  config {
+    required_field = "unclosed string
+  }
+}
+`
+
+	err := os.WriteFile(testFile, []byte(hclContent), 0644)
+	require.NoError(t, err)
+
+	// Create parser and register plugin
+	parser := NewParser(nil)
+	plugin := &ErrorTestPlugin{}
+	err = parser.RegisterPlugin(plugin)
+	require.NoError(t, err)
+
+	parser.GetPluginRegistry().RegisterPluginSource("test/error", plugin)
+
+	// Parse should fail due to malformed HCL
+	_, err = parser.ParseFile(testFile)
+	require.Error(t, err)
+	// Should be an HCL parsing error
+}
+
+func TestProviderErrorDuplicateProviderNames(t *testing.T) {
+	// Create temporary test file with duplicate provider names
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.hcl")
+
+	hclContent := `
+provider "duplicate" {
+  source = "test/error"
+  version = "1.0.0"
+  
+  config {
+    required_field = "first"
+  }
+}
+
+provider "duplicate" {
+  source = "test/error"
+  version = "1.0.0"
+  
+  config {
+    required_field = "second"
+  }
+}
+`
+
+	err := os.WriteFile(testFile, []byte(hclContent), 0644)
+	require.NoError(t, err)
+
+	// Create parser and register plugin
+	parser := NewParser(nil)
+	plugin := &ErrorTestPlugin{}
+	err = parser.RegisterPlugin(plugin)
+	require.NoError(t, err)
+
+	parser.GetPluginRegistry().RegisterPluginSource("test/error", plugin)
+
+	// Parse should fail due to duplicate provider names
+	_, err = parser.ParseFile(testFile)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "already defined")
+}
+
+func TestProviderErrorMissingPluginForResource(t *testing.T) {
+	// Create temporary test file with resource that has no registered plugin
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.hcl")
+
+	hclContent := `
+resource "unregistered_type" "test" {
+  data = "should fail"
+}
+`
+
+	err := os.WriteFile(testFile, []byte(hclContent), 0644)
+	require.NoError(t, err)
+
+	// Create parser without registering the required plugin
+	parser := NewParser(nil)
+
+	// Parse should fail due to unregistered resource type
+	_, err = parser.ParseFile(testFile)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found") // Should mention type not found
+}
+
+func TestProviderErrorInvalidVariableReference(t *testing.T) {
+	// Create temporary test file with invalid variable reference
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.hcl")
+
+	hclContent := `
+provider "error_test" {
+  source = "test/error"
+  version = "1.0.0"
+  
+  config {
+    required_field = variable.nonexistent_var
+  }
+}
+`
+
+	err := os.WriteFile(testFile, []byte(hclContent), 0644)
+	require.NoError(t, err)
+
+	// Create parser and register plugin
+	parser := NewParser(nil)
+	plugin := &ErrorTestPlugin{}
+	err = parser.RegisterPlugin(plugin)
+	require.NoError(t, err)
+
+	parser.GetPluginRegistry().RegisterPluginSource("test/error", plugin)
+
+	// Parse should fail due to undefined variable
+	_, err = parser.ParseFile(testFile)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "variable") // Should mention variable issue
+}
+
+func TestProviderErrorEmptyProvider(t *testing.T) {
+	// Create temporary test file with completely empty provider block
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.hcl")
+
+	hclContent := `
+provider "empty" {
+  # No source, version, or config
+}
+`
+
+	err := os.WriteFile(testFile, []byte(hclContent), 0644)
+	require.NoError(t, err)
+
+	// Create parser
+	parser := NewParser(nil)
+
+	// Parse should fail due to missing required fields
+	_, err = parser.ParseFile(testFile)
+	require.Error(t, err)
+}
+
+func TestProviderErrorCircularVariableReference(t *testing.T) {
+	// Create temporary test file with circular variable references
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.hcl")
+
+	hclContent := `
+variable "var1" {
+  default = variable.var2
+}
+
+variable "var2" {
+  default = variable.var1
+}
+
+provider "error_test" {
+  source = "test/error"
+  version = "1.0.0"
+  
+  config {
+    required_field = variable.var1
+  }
+}
+`
+
+	err := os.WriteFile(testFile, []byte(hclContent), 0644)
+	require.NoError(t, err)
+
+	// Create parser and register plugin
+	parser := NewParser(nil)
+	plugin := &ErrorTestPlugin{}
+	err = parser.RegisterPlugin(plugin)
+	require.NoError(t, err)
+
+	parser.GetPluginRegistry().RegisterPluginSource("test/error", plugin)
+
+	// Parse should fail due to circular reference
+	_, err = parser.ParseFile(testFile)
+	require.Error(t, err)
+	// The exact error message depends on HCL's cycle detection
+}
+
+func TestProviderErrorTrulyUndefinedVariable(t *testing.T) {
+	// This test uses a variable that is never defined anywhere
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.hcl")
+
+	hclContent := `
+provider "simple" {
+  source = "test/simple"
+  version = "1.0.0"
+  
+  config {
+    value = variable.truly_undefined_variable  # This variable is never defined
+  }
+}
+`
+
+	err := os.WriteFile(testFile, []byte(hclContent), 0644)
+	require.NoError(t, err)
+
+	// Create parser and register plugin
+	parser := NewParser(nil)
+	plugin := &SimplePlugin{}
+	err = parser.RegisterPlugin(plugin)
+	require.NoError(t, err)
+
+	parser.GetPluginRegistry().RegisterPluginSource("test/simple", plugin)
+
+	// Parse should fail due to truly undefined variable
+	_, err = parser.ParseFile(testFile)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "variable") // Should mention variable issue
+	
+	t.Logf("Parse failed as expected with undefined variable: %v", err)
+}
+
+func TestProviderErrorInvalidSourcePath(t *testing.T) {
+	// Test with malformed source path
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.hcl")
+
+	hclContent := `
+provider "simple" {
+  source = "invalid-source-path"  # Invalid source format
+  version = "1.0.0"
+  
+  config {
+    value = "test"
+  }
+}
+`
+
+	err := os.WriteFile(testFile, []byte(hclContent), 0644)
+	require.NoError(t, err)
+
+	// Create parser and register plugin
+	parser := NewParser(nil)
+	plugin := &SimplePlugin{}
+	err = parser.RegisterPlugin(plugin)
+	require.NoError(t, err)
+
+	// Deliberately NOT registering the source "invalid-source-path"
+
+	// Parse should fail due to source not found
+	_, err = parser.ParseFile(testFile)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+	
+	t.Logf("Parse failed as expected with invalid source: %v", err)
+}

--- a/plugin_registry_test.go
+++ b/plugin_registry_test.go
@@ -516,8 +516,8 @@ provider "error_test" {
 	err := os.WriteFile(testFile, []byte(hclContent), 0644)
 	require.NoError(t, err)
 
-	// Create parser and register plugin
-	parser := NewParser(nil)
+	// Create parser with proper test isolation
+	parser, _ := setupParser(t)
 	plugin := &ErrorTestPlugin{}
 	err = parser.RegisterPlugin(plugin)
 	require.NoError(t, err)
@@ -549,8 +549,8 @@ provider "error_test" {
 	err := os.WriteFile(testFile, []byte(hclContent), 0644)
 	require.NoError(t, err)
 
-	// Create parser and register plugin with different source
-	parser := NewParser(nil)
+	// Create parser with proper test isolation
+	parser, _ := setupParser(t)
 	plugin := &ErrorTestPlugin{}
 	err = parser.RegisterPlugin(plugin)
 	require.NoError(t, err)
@@ -582,8 +582,8 @@ provider "error_test" {
 	err := os.WriteFile(testFile, []byte(hclContent), 0644)
 	require.NoError(t, err)
 
-	// Create parser and register plugin
-	parser := NewParser(nil)
+	// Create parser with proper test isolation
+	parser, _ := setupParser(t)
 	plugin := &ErrorTestPlugin{}
 	err = parser.RegisterPlugin(plugin)
 	require.NoError(t, err)
@@ -624,8 +624,8 @@ provider "duplicate" {
 	err := os.WriteFile(testFile, []byte(hclContent), 0644)
 	require.NoError(t, err)
 
-	// Create parser and register plugin
-	parser := NewParser(nil)
+	// Create parser with proper test isolation
+	parser, _ := setupParser(t)
 	plugin := &ErrorTestPlugin{}
 	err = parser.RegisterPlugin(plugin)
 	require.NoError(t, err)
@@ -652,8 +652,8 @@ resource "unregistered_type" "test" {
 	err := os.WriteFile(testFile, []byte(hclContent), 0644)
 	require.NoError(t, err)
 
-	// Create parser without registering the required plugin
-	parser := NewParser(nil)
+	// Create parser with proper test isolation
+	parser, _ := setupParser(t)
 
 	// Parse should fail due to unregistered resource type
 	_, err = parser.ParseFile(testFile)
@@ -680,8 +680,8 @@ provider "error_test" {
 	err := os.WriteFile(testFile, []byte(hclContent), 0644)
 	require.NoError(t, err)
 
-	// Create parser and register plugin
-	parser := NewParser(nil)
+	// Create parser with proper test isolation
+	parser, _ := setupParser(t)
 	plugin := &ErrorTestPlugin{}
 	err = parser.RegisterPlugin(plugin)
 	require.NoError(t, err)
@@ -708,8 +708,8 @@ provider "empty" {
 	err := os.WriteFile(testFile, []byte(hclContent), 0644)
 	require.NoError(t, err)
 
-	// Create parser
-	parser := NewParser(nil)
+	// Create parser with proper test isolation
+	parser, _ := setupParser(t)
 
 	// Parse should fail due to missing required fields
 	_, err = parser.ParseFile(testFile)
@@ -743,8 +743,8 @@ provider "error_test" {
 	err := os.WriteFile(testFile, []byte(hclContent), 0644)
 	require.NoError(t, err)
 
-	// Create parser and register plugin
-	parser := NewParser(nil)
+	// Create parser with proper test isolation
+	parser, _ := setupParser(t)
 	plugin := &ErrorTestPlugin{}
 	err = parser.RegisterPlugin(plugin)
 	require.NoError(t, err)
@@ -776,8 +776,8 @@ provider "simple" {
 	err := os.WriteFile(testFile, []byte(hclContent), 0644)
 	require.NoError(t, err)
 
-	// Create parser and register plugin
-	parser := NewParser(nil)
+	// Create parser with proper test isolation
+	parser, _ := setupParser(t)
 	plugin := &SimplePlugin{}
 	err = parser.RegisterPlugin(plugin)
 	require.NoError(t, err)
@@ -811,8 +811,8 @@ provider "simple" {
 	err := os.WriteFile(testFile, []byte(hclContent), 0644)
 	require.NoError(t, err)
 
-	// Create parser and register plugin
-	parser := NewParser(nil)
+	// Create parser with proper test isolation
+	parser, _ := setupParser(t)
 	plugin := &SimplePlugin{}
 	err = parser.RegisterPlugin(plugin)
 	require.NoError(t, err)

--- a/plugin_registry_test.go
+++ b/plugin_registry_test.go
@@ -115,7 +115,6 @@ func TestPluginRegistryRegisterProvider(t *testing.T) {
 	require.Equal(t, "test-provider", providerConfig.Metadata().Name)
 	require.Equal(t, "test/provider", providerConfig.Source)
 	require.Equal(t, "1.0.0", providerConfig.Version)
-	require.Equal(t, plugin, providerConfig.Plugin)
 }
 
 func TestRegisterProviderDuplicateName(t *testing.T) {
@@ -717,36 +716,13 @@ provider "empty" {
 }
 
 func TestProviderErrorCircularVariableReference(t *testing.T) {
-	// Create temporary test file with circular variable references
-	tmpDir := t.TempDir()
-	testFile := filepath.Join(tmpDir, "test.hcl")
-
-	hclContent := `
-variable "var1" {
-  default = variable.var2
-}
-
-variable "var2" {
-  default = variable.var1
-}
-
-provider "error_test" {
-  source = "test/error"
-  version = "1.0.0"
-  
-  config {
-    required_field = variable.var1
-  }
-}
-`
-
-	err := os.WriteFile(testFile, []byte(hclContent), 0644)
-	require.NoError(t, err)
+	// Use test fixture for circular variable references
+	testFile := "./internal/test_fixtures/config/providers/circular_variables.hcl"
 
 	// Create parser with proper test isolation
 	parser, _ := setupParser(t)
 	plugin := &ErrorTestPlugin{}
-	err = parser.RegisterPlugin(plugin)
+	err := parser.RegisterPlugin(plugin)
 	require.NoError(t, err)
 
 	parser.GetPluginRegistry().RegisterPluginSource("test/error", plugin)

--- a/plugins/datasource.go
+++ b/plugins/datasource.go
@@ -9,15 +9,17 @@ import (
 // DataSourceProvider defines the generic interface that all data source providers must implement.
 // Data sources are read-only resources that fetch external data and return it as a typed resource.
 // T must be a type that implements types.Resource.
-type DataSourceProvider[T types.Resource] interface {
-	// Init initializes the provider with state access, provider functions, and a logger.
+// C represents the configuration type for the provider.
+type DataSourceProvider[T types.Resource, C any] interface {
+	// Init initializes the provider with state access, provider functions, logger, and configuration.
 	// This method is called once when the provider is created and should be used
 	// to set up any required clients or dependencies.
 	//
 	// The state parameter provides access to the current state of resources.
 	// The functions parameter provides access to provider-defined functions.
 	// The logger parameter is the logger instance for all logging operations.
-	Init(state State, functions ProviderFunctions, logger Logger) error
+	// The config parameter contains the typed configuration for this provider instance.
+	Init(state State, functions ProviderFunctions, logger Logger, config C) error
 
 	// Refresh fetches external data and returns it as a typed resource.
 	// This method is called to retrieve the latest data from the external source.

--- a/plugins/example/main.go
+++ b/plugins/example/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"reflect"
+
 	"github.com/hashicorp/go-plugin"
 	"github.com/jumppad-labs/hclconfig/logger"
 	"github.com/jumppad-labs/hclconfig/plugins"
@@ -13,6 +15,11 @@ type PersonPlugin struct {
 	plugins.PluginBase
 }
 
+// GetConfigType returns the configuration type for this plugin
+func (p *PersonPlugin) GetConfigType() reflect.Type {
+	return reflect.TypeOf(person.ExampleProviderConfig{})
+}
+
 // Ensure PersonPlugin implements the Plugin interface
 var _ plugins.Plugin = (*PersonPlugin)(nil)
 
@@ -22,6 +29,7 @@ func (p *PersonPlugin) Init(logger logger.Logger, state plugins.State) error {
 	// Create instances of resources and providers
 	personResource := &person.Person{}
 	personProvider := &person.ExampleProvider{}
+	personConfig := person.ExampleProviderConfig{}
 
 	// Register the Person resource type
 	err := plugins.RegisterResourceProvider(
@@ -32,6 +40,7 @@ func (p *PersonPlugin) Init(logger logger.Logger, state plugins.State) error {
 		"person",       // Sub-type (your specific resource type)
 		personResource, // Instance of the resource struct
 		personProvider, // Instance of the provider
+		personConfig,   // Provider config instance
 	)
 
 	if err != nil {

--- a/plugins/example/pkg/person/provider.go
+++ b/plugins/example/pkg/person/provider.go
@@ -7,6 +7,11 @@ import (
 	"github.com/jumppad-labs/hclconfig/plugins"
 )
 
+// ExampleProviderConfig represents the configuration for the example provider
+type ExampleProviderConfig struct {
+	// Empty config for this example
+}
+
 // ExampleProvider is a basic implementation of Provider[*Person]
 // that demonstrates the structure and lifecycle methods for Person resources.
 type ExampleProvider struct {
@@ -15,10 +20,10 @@ type ExampleProvider struct {
 	logger    logger.Logger
 }
 
-// Compile-time check to ensure ExampleProvider implements ResourceProvider[*Person]
-var _ plugins.ResourceProvider[*Person] = (*ExampleProvider)(nil)
+// Compile-time check to ensure ExampleProvider implements ResourceProvider[*Person, ExampleProviderConfig]
+var _ plugins.ResourceProvider[*Person, ExampleProviderConfig] = (*ExampleProvider)(nil)
 
-func (p *ExampleProvider) Init(state plugins.State, functions plugins.ProviderFunctions, logger logger.Logger) error {
+func (p *ExampleProvider) Init(state plugins.State, functions plugins.ProviderFunctions, logger logger.Logger, config ExampleProviderConfig) error {
 	p.state = state
 	p.functions = functions
 	p.logger = logger

--- a/plugins/provider.go
+++ b/plugins/provider.go
@@ -15,15 +15,17 @@ import (
 // It provides lifecycle management for resources including creation, destruction,
 // refresh, and state checking operations.
 // T must be a type that implements types.Resource.
-type ResourceProvider[T types.Resource] interface {
-	// Init initializes the provider with state access, provider functions, and a logger.
+// C represents the configuration type for the provider.
+type ResourceProvider[T types.Resource, C any] interface {
+	// Init initializes the provider with state access, provider functions, logger, and configuration.
 	// This method is called once when the provider is created and should be used
 	// to set up any required clients or dependencies.
 	//
 	// The state parameter provides access to the current state of resources.
 	// The functions parameter provides access to provider-defined functions.
 	// The logger parameter is the logger instance for all logging operations.
-	Init(state State, functions ProviderFunctions, logger Logger) error
+	// The config parameter contains the typed configuration for this provider instance.
+	Init(state State, functions ProviderFunctions, logger Logger, config C) error
 
 	// Create creates a new resource or recreates a failed resource.
 	// This method is called when a resource does not exist or when creation

--- a/pretty_printer.go
+++ b/pretty_printer.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/jumppad-labs/hclconfig/internal/resources"
 	"github.com/jumppad-labs/hclconfig/types"
 	"github.com/mitchellh/go-wordwrap"
 )
@@ -729,11 +730,11 @@ func (p *ResourcePrinter) getResourceEmoji(resourceType string) string {
 		return "🌐"
 	case "volume":
 		return "💾"
-	case "variable":
+	case resources.TypeVariable:
 		return "🔧"
-	case "output":
+	case resources.TypeOutput:
 		return "📤"
-	case "module":
+	case resources.TypeModule:
 		return "📦"
 	case "template":
 		return "📄"

--- a/test_plugin.go
+++ b/test_plugin.go
@@ -10,10 +10,17 @@ import (
 	"github.com/jumppad-labs/hclconfig/types"
 )
 
+// TestPluginConfig represents the configuration for the test plugin
+type TestPluginConfig struct {
+	// Empty config for testing
+}
+
 // TestPlugin provides test resource types for testing the parser
 type TestPlugin struct {
 	plugins.PluginBase
 }
+
+// GetConfigType is now automatically provided by PluginBase
 
 // Ensure TestPlugin implements Plugin interface
 var _ plugins.Plugin = (*TestPlugin)(nil)
@@ -23,6 +30,7 @@ func (p *TestPlugin) Init(logger logger.Logger, state plugins.State) error {
 	// Register Container resource
 	containerResource := &structs.Container{}
 	containerProvider := &TestResourceProvider[*structs.Container]{}
+	var config TestPluginConfig
 	err := plugins.RegisterResourceProvider(
 		&p.PluginBase,
 		logger,
@@ -31,6 +39,7 @@ func (p *TestPlugin) Init(logger logger.Logger, state plugins.State) error {
 		"container",
 		containerResource,
 		containerProvider,
+		config,
 	)
 	if err != nil {
 		return err
@@ -46,6 +55,7 @@ func (p *TestPlugin) Init(logger logger.Logger, state plugins.State) error {
 		"sidecar",
 		sidecarResource,
 		sidecarProvider,
+		config,
 	)
 	if err != nil {
 		return err
@@ -62,6 +72,7 @@ func (p *TestPlugin) Init(logger logger.Logger, state plugins.State) error {
 		"network",
 		networkResource,
 		networkProvider,
+		config,
 	)
 	if err != nil {
 		return err
@@ -78,6 +89,7 @@ func (p *TestPlugin) Init(logger logger.Logger, state plugins.State) error {
 		"template",
 		templateResource,
 		templateProvider,
+		config,
 	)
 	if err != nil {
 		return err
@@ -94,7 +106,7 @@ type TestResourceProvider[T types.Resource] struct {
 }
 
 // Init initializes the test provider
-func (p *TestResourceProvider[T]) Init(state plugins.State, functions plugins.ProviderFunctions, logger logger.Logger) error {
+func (p *TestResourceProvider[T]) Init(state plugins.State, functions plugins.ProviderFunctions, logger logger.Logger, config TestPluginConfig) error {
 	p.state = state
 	p.functions = functions
 	p.logger = logger
@@ -150,6 +162,8 @@ type EmbeddedTestPlugin struct {
 	plugins.PluginBase
 }
 
+// GetConfigType is now automatically provided by PluginBase
+
 // Ensure EmbeddedTestPlugin implements Plugin interface
 var _ plugins.Plugin = (*EmbeddedTestPlugin)(nil)
 
@@ -158,6 +172,7 @@ func (p *EmbeddedTestPlugin) Init(logger logger.Logger, state plugins.State) err
 	// Register Container resource
 	containerResource := &embedded.Container{}
 	containerProvider := &TestResourceProvider[*embedded.Container]{}
+	var config TestPluginConfig
 	err := plugins.RegisterResourceProvider(
 		&p.PluginBase,
 		logger,
@@ -166,6 +181,7 @@ func (p *EmbeddedTestPlugin) Init(logger logger.Logger, state plugins.State) err
 		"container",
 		containerResource,
 		containerProvider,
+		config,
 	)
 	if err != nil {
 		return err
@@ -182,6 +198,7 @@ func (p *EmbeddedTestPlugin) Init(logger logger.Logger, state plugins.State) err
 		"sidecar",
 		sidecarResource,
 		sidecarProvider,
+		config,
 	)
 	if err != nil {
 		return err

--- a/types/resource.go
+++ b/types/resource.go
@@ -88,6 +88,9 @@ type ResourceBase struct {
 	// Enabled determines if a resource is enabled and should be processed
 	Disabled bool `hcl:"disabled,optional" json:"disabled,omitempty"`
 
+	// Provider specifies which provider instance should handle this resource
+	Provider string `hcl:"provider,optional" json:"provider,omitempty"`
+
 	Meta Meta `hcl:"meta,optional" json:"meta,omitempty"`
 }
 

--- a/utils.go
+++ b/utils.go
@@ -68,10 +68,19 @@ func HashString(in string) string {
 // Rock the cast var
 func castVar(v cty.Value) any {
 	if v.Type() == cty.String {
+		if v.IsNull() {
+			return nil
+		}
 		return v.AsString()
 	} else if v.Type() == cty.Bool {
+		if v.IsNull() {
+			return nil
+		}
 		return v.True()
 	} else if v.Type() == cty.Number {
+		if v.IsNull() {
+			return nil
+		}
 		// If something blows up here, remember that conversation we had when
 		// we said that nobody will ever use a number bigger than float64 ... yeah
 		// Handlebars does not understand BigFloat.

--- a/utils_test.go
+++ b/utils_test.go
@@ -30,6 +30,7 @@ func TestCalculatesHashFromString(t *testing.T) {
 
 var singleLine = `resource "container" "consul"`
 
+// Expected content from lines 13-32 of ./internal/test_fixtures/config/single/container.hcl
 var container = `resource "container" "consul" {
   command = ["consul", "agent", "-dev", "-client", "0.0.0.0"]
 


### PR DESCRIPTION
# Provider Configuration with DAG Integration

## Summary
- **Major architectural change**: Moved providers into the DAG system, enabling provider configurations to reference values from resources and variables
- **Provider lifecycle management**: Providers are now initialized during DAG execution with full dependency resolution
- **Enhanced referenceability**: Provider config fields are now referenceable in HCL expressions (e.g., `provider.database.config.value`)
- **Test isolation improvements**: Fixed all tests to use proper test isolation patterns and removed unnecessary duration testing
- **Comprehensive test coverage**: Added extensive tests for provider-resource dependencies and DAG integration

## Key Changes

### Architectural Transformation
- **Providers in DAG**: Removed provider exclusion from DAG processing, making them full participants in dependency resolution
- **Automatic dependencies**: Resources automatically depend on their providers, ensuring proper execution order
- **Deferred initialization**: Provider initialization moved from parsing time to DAG execution time for proper context resolution
- **Enhanced referenceability**: Early resolution of simple provider configs during parsing for better HCL referenceability

### Provider Lifecycle Management
- **New `initializeProvider()`**: Handles provider initialization during DAG execution with full evaluation context
- **New `getResourceProviderName()`**: Extracts provider names from resources using reflection for explicit and implicit providers
- **New `updateProviderContextVariable()`**: Updates provider context variables with resolved config values
- **Enhanced `callProviderLifecycle()`**: Now handles both provider initialization and resource lifecycle operations

### DAG Integration
- **Provider dependencies**: Added automatic provider dependency logic in `doYaLikeDAGs()`
- **Special provider handling**: Modified `walkCallback()` to handle providers with global context access
- **Resource-provider linking**: Resources now properly depend on their providers in the dependency graph
- **Module support**: Provider dependencies work correctly across module boundaries

### Parser Improvements
- **Deferred registration**: Providers are stored but not fully initialized during parsing
- **Early config resolution**: Simple configs (variables/literals) are resolved during parsing for referenceability
- **Duplicate detection**: Improved provider name validation without premature initialization
- **Context management**: Better separation between parsing context and execution context

## Testing Improvements
- **Test isolation**: Fixed all tests to use `setupParser(t)` instead of manual `NewParser()` construction
- **Removed duration testing**: Eliminated unnecessary and unreliable duration assertions from event tests
- **Removed production sleeps**: Removed artificial delays that were added solely for test compatibility
- **Provider dependency tests**: Added comprehensive tests in `dag_test.go` for provider-resource dependencies
- **Error scenario testing**: Enhanced error callback testing with proper state setup

## Key Features Enabled
- **Variable-driven providers**: Provider configs can reference variables (e.g., `provider.db { host = variable.db_host }`)
- **Resource-driven providers**: Provider configs can reference resource outputs (e.g., certificates from other resources)
- **Config referenceability**: Provider config fields accessible in expressions (e.g., `provider.k8s.config.endpoint`)
- **Terraform-like enforcement**: Resources MUST have corresponding provider blocks defined
- **Full lifecycle support**: Providers support init, create, refresh, update, destroy operations

## Advanced Use Cases
This implementation enables powerful patterns like:
```hcl
resource "tls_cert" "ca" {
  # Generate a CA certificate
}

provider "kubernetes" {
  config {
    ca_certificate = resource.tls_cert.ca.cert_pem
    endpoint = "https://k8s.example.com"
  }
}

resource "k8s_deployment" "app" {
  provider = "kubernetes"
  # This deployment uses the dynamically configured k8s provider
}
```

## Integration
- Successfully builds on existing provider configuration branch
- All existing tests pass with no regressions
- Maintains backward compatibility for simple provider configs
- Enhanced error handling and validation
- Proper event firing for all provider operations

## Test Plan
- [x] All unit tests pass (`go test -v`)
- [x] Provider dependency tests pass
- [x] DAG integration tests pass
- [x] Event callback tests pass (without duration requirements)
- [x] Error scenario tests pass
- [x] No import cycle issues
- [x] Module-scoped provider dependencies work
- [x] Resource-provider enforcement works
- [x] Provider config referenceability works

This represents a significant architectural advancement that brings provider configuration capabilities much closer to Terraform's model while maintaining the flexibility and power of the existing HCL configuration system.