### PR TITLE
Fix disabled modules validating resource links

### DIFF
--- a/dag.go
+++ b/dag.go
@@ -455,6 +455,12 @@ func validateLinkedResources(c *Config, r types.Resource, values []string) error
 				fmt.Sprintf("unable to find dependent resource '%s': %s", value, err))
 		}
 
+		// skip deep attribute validation for disabled resources as their
+		// structs were never decoded and will have zero-value fields
+		if l.GetDisabled() {
+			continue
+		}
+
 		attr := fqrn.Attribute
 		if fqrn.Type == "output" {
 			if attr == "" {

--- a/parse_test.go
+++ b/parse_test.go
@@ -707,6 +707,37 @@ func TestParseDoesNotProcessDisabledResourcesWhenModuleDisabled(t *testing.T) {
 	require.Len(t, calls, 5)
 }
 
+func TestDisabledModuleWithIndexedReferencesDoesNotError(t *testing.T) {
+	absoluteFolderPath, err := filepath.Abs("./test_fixtures/disabled/disabled_module_with_outputs.hcl")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	o := DefaultOptions()
+	calls := []string{}
+	callSync := sync.Mutex{}
+	o.Callback = func(r types.Resource) error {
+		callSync.Lock()
+		calls = append(calls, r.Metadata().ID)
+		callSync.Unlock()
+
+		return nil
+	}
+
+	p := setupParser(t, o)
+
+	c, err := p.ParseFile(absoluteFolderPath)
+	require.NoError(t, err)
+
+	m, err := c.FindResource("module.disabled_outputs")
+	require.NoError(t, err)
+	require.True(t, m.GetDisabled())
+
+	r, err := c.FindResource("module.disabled_outputs.resource.container.service")
+	require.NoError(t, err)
+	require.True(t, r.GetDisabled())
+}
+
 func TestGetNameAndIndexReturnsCorrectDetails(t *testing.T) {
 	path := []string{"resource", "foo", "bar"}
 	n, i, rp, err := getNameAndIndex(path)

--- a/test_fixtures/disabled/disabled_module_with_outputs.hcl
+++ b/test_fixtures/disabled/disabled_module_with_outputs.hcl
@@ -1,0 +1,4 @@
+module "disabled_outputs" {
+  disabled = true
+  source   = "./modules_with_outputs"
+}

--- a/test_fixtures/disabled/modules_with_outputs/resources.hcl
+++ b/test_fixtures/disabled/modules_with_outputs/resources.hcl
@@ -1,0 +1,18 @@
+resource "container" "service" {
+  command = ["tail", "-f", "/dev/null"]
+
+  network {
+    name = "main"
+  }
+
+  dns = ["a", "b", "c"]
+
+  resources {
+    memory  = 1024
+    cpu_pin = [1]
+  }
+}
+
+output "service_address" {
+  value = resource.container.service.network[0].name
+}


### PR DESCRIPTION
## Summary

- Move the disabled resource early-return check before `getBody`, `getContext`, and `validateLinkedResources` in `createCallback`
- Previously, resources inside disabled modules had their links validated against other disabled resources whose structs were never decoded, causing `list does not contain index: "0"` errors on slice access like `network[0].assigned_address`
- Add test and fixture for a disabled module containing indexed output references